### PR TITLE
add installation instructions to readme copied from the word doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,43 @@
 **/target
-**/.vscode
-**/.project
-**/.classpath
 tmp
 **/\.~lock*
+
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,57 @@
 # rest_api
-Rest API that serves OpenDCS database objects as JSON
+OpenDCS Rest API is web application that provides access to the OpenDCS database using JSON (Java Script Object Notation).
+OpenDCS Rest API is intended to run as a stand-alone Java program. It uses embedded JETTY to implement the web services.
 
-The installation and configuration of the API is documented in the opendcs-restapi.docx file (the doc-source directory).
+# Installation and Configuration
+There are two types of installations/configurations.  One is Jetty and the other is a WAR file.
+
+The Root URL for the service is specified using the command line arguments when the JETTY server is started. If the defaults are used, you can access the service from the local machine with:
+http://localhost:8080/odcsapi/function-call
+
+For example, to get a list of platform references:
+http://localhost:8080/odcsapi/platformrefs
+
+##	Jetty
+-	Change directory to the base directory of the project.
+-	Run the following command: `mvn install`
+-	In the ‘target’ directory, there will be a .tar.gz file.  This is the newly created jetty tar ball.
+-	Move the tar ball to the desired location and extract it.
+-	Then change directory to the ‘bin’ directory.  There will be a ‘start.sh’ file.
+-	Create a shell script, to run start.sh with some extra configurations.
+     - Example shell script:
+        ```
+        export DCSTOOL_HOME=/home/opendcs/OPENDCS
+        export DCSTOOL_USERDIR=/home/opendcs
+        export JAVA_OPTS="-DDCSTOOL_HOME=$DCSTOOL_HOME -DDCSTOOL_USERDIR=$DCSTOOL_USERDIR"
+        export JAVA_ARGS="-p 8081 -c odcsapi -cors /home/testuser/OPENDCS/opendcs_web_cors.cfg -s"
+        ./start.sh
+        ```
+- The java args help configure the server
+     - -cors
+          -	A cors file that helps configure the cors settings of the server.  Below is an example of text in a cors file.
+          ```
+          Access-Control-Allow-Origin:*
+          Access-Control-Allow-Headers:X-Requested-With,Content-Type,Accept,Origin,authorization
+          Access-Control-Allow-Methods:GET,POST,HEAD,OPTIONS,DELETE
+          ```
+     - -c
+       - The context (relative url path) of the API.
+  - -p
+      - HTTP port number
+  - -sp
+    - HTTPS port number.  Requires a key and a key password to work.
+  - -key
+    - Path to a key that can be accessed by the webserver.
+  - -kp
+    - Key Password (the password that was used to generate the key).
+  - -P
+    - Decodes Properties file path (by default it’s at $DCSTOOL_HOME/decodes.properties.
+  - -s
+    - Secure mode.  The authentication is done via the header, rather than as parameters passed through parameters.
+
+## WAR file
+Once mvn install has been run to create a jetty instance, a war file can then be created.
+- Run the following command after the jetty embedded server tar ball is created
+- ant -f build-war.xml war
+
+


### PR DESCRIPTION
## Problem Description

Wanting installation instructions added to the README.md instead of searching in the word doc.

## Solution

Added the installation instructions from the word doc to the README.md in markdown format.

## how you tested the change

N/A

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [X] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
