### PR TITLE
fix directory for manifest classspath

### DIFF
--- a/odcs-web-client-jetty-standalone/build.gradle
+++ b/odcs-web-client-jetty-standalone/build.gradle
@@ -16,7 +16,7 @@ jar {
     manifest {
         attributes(
                 'Main-Class': 'org.opendcs.odcswebclient.jetty.Start',
-                'Class-Path': configurations.runtimeClasspath.files.collect { it.getName() }.join(' ')
+                'Class-Path': configurations.runtimeClasspath.files.collect { "libs/" + it.getName() }.join(' ')
         )
     }
 }

--- a/odcsapi-jetty-standalone/build.gradle
+++ b/odcsapi-jetty-standalone/build.gradle
@@ -20,7 +20,7 @@ jar {
     manifest {
         attributes(
                 'Main-Class': 'org.opendcs.odcsapi.jetty.Start',
-                'Class-Path': configurations.runtimeClasspath.files.collect { it.getName() }.join(' ')
+                'Class-Path': configurations.runtimeClasspath.files.collect { "libs/" + it.getName() }.join(' ')
         )
     }
 }


### PR DESCRIPTION
## Problem Description

Manifest classpath was looking for jars in the root directory.

## Solution

Prepend the "libs/" directory during the manifest creation.

## how you tested the change

Tested through the bash script.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

