### PR TITLE
add PR batching for all minor/patch dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      alldependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     reviewers:
       - "@opendcs/opendcs-core-devs"


### PR DESCRIPTION
## Problem Description

Dependabot by default creates a PR for every dependency update. This is pretty spammy and not as useful as batching multiple updates together.

Issue #40

## Solution

Use the Dependabot configuration to batch PR's as long as the updates are minor and patch (definitely could be convinced to batch all updates).

## how you tested the change

N/A

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

