### PR TITLE
update github actions to target specific versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,16 @@ updates:
           - "patch"
     reviewers:
       - "@opendcs/opendcs-core-devs"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      alldependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "@opendcs/opendcs-core-devs"

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -9,24 +9,24 @@ on:
 jobs:
   build:
     name: Build, Test, and Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: 17
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -41,14 +41,14 @@ jobs:
       - name: Bundle tarballs
         run: ./gradlew bundle
       - name: Upload WAR files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: warfile
           path: ./**/build/libs/*.war
           retention-days: 1
           if-no-files-found: error
       - name: Upload Tarballs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: opendcs-rest-api-artifacts
           path: ./**/build/distributions/*.tar.gz

--- a/.github/workflows/java_compatibility.yml
+++ b/.github/workflows/java_compatibility.yml
@@ -10,20 +10,20 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
     name: Build on Java ${{ matrix.Java }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Problem Description

GitHub workflow actions targeted major versions only instead of targeting specific releases. This is a security concern as the latest minor/patch versions could be compromised.

## Solution

Target specific versions. I did not target hashes as all of the actions are from the GitHub Actions organization. For other owners I think we'd want to target commit hashes.

Added dependabot weekly task for updating the actions.

## how you tested the change

Will test on this PR.

## Where the following done:

- [X] Were relevant config element (e.g. XML data) updated as appropriate

