### PR TITLE
update setup java - missed a version to pin

### DIFF
--- a/.github/workflows/java_compatibility.yml
+++ b/.github/workflows/java_compatibility.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'


### PR DESCRIPTION
## Problem Description

Missed a pinned github action. Dependabot found it for me.

## Solution

Update to pinned v4.0.0 for setup-java

## how you tested the change

Testing in PR

## Where the following done:

- [X] Were relevant config element (e.g. XML data) updated as appropriate
