### PR TITLE
Remove insecure printStackTrace calls.

### DIFF
--- a/opendcs-rest-api-jetty/src/main/java/org/opendcs/odcsapi/jetty/Start.java
+++ b/opendcs-rest-api-jetty/src/main/java/org/opendcs/odcsapi/jetty/Start.java
@@ -31,9 +31,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.DispatcherType;
 
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.servlet.DefaultServlet;

--- a/opendcs-rest-api-jetty/src/main/java/org/opendcs/odcsapi/jetty/Start.java
+++ b/opendcs-rest-api-jetty/src/main/java/org/opendcs/odcsapi/jetty/Start.java
@@ -31,11 +31,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.DispatcherType;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
-import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.servlet.DefaultServlet;

--- a/opendcs-rest-api/build.gradle
+++ b/opendcs-rest-api/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation(libs.json.jackson)
     implementation(libs.jersey.container.servlet)
     implementation(libs.jersey.hk2)
+    implementation(libs.slf4j.jdk)
     runtimeOnly(libs.jaxb.runtime)
     runtimeOnly(libs.postgresql)
     webjars(libs.swagger.ui)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/errorhandling/WebAppException.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/errorhandling/WebAppException.java
@@ -24,11 +24,18 @@ public class WebAppException
 	private Integer status = 0;
 
 	/** detailed error msg */
-	private String errMessage = "";	
-	
+	private String errMessage = "";
+
 	public WebAppException(Integer status, String errMessage)
 	{
-		super();
+		super(errMessage);
+		this.status = status;
+		this.errMessage = errMessage;
+	}
+
+	public WebAppException(Integer status, String errMessage, Throwable throwable)
+	{
+		super(errMessage, throwable);
 		this.status = status;
 		this.errMessage = errMessage;
 	}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/ApiLddsClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/ApiLddsClient.java
@@ -537,8 +537,6 @@ debug(module + ".sendAuthHello authenticator '" + authStr + "'");
 		{
 			String em = "Error in LrgsStatusXio: " + ex;
 			warning(em);
-			System.err.println(em);
-			ex.printStackTrace();
 			throw new DdsProtocolError(em);
 		}
 	}
@@ -602,8 +600,6 @@ debug(module + ".sendAuthHello authenticator '" + authStr + "'");
 		{
 			String em = "Error in RawMessageBlockParser: " + ex;
 			warning(em);
-			System.err.println(em);
-			ex.printStackTrace();
 			throw new DdsProtocolError(em);
 		}
 	}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/ApiLddsClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/ApiLddsClient.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.zip.GZIPInputStream;
@@ -55,6 +56,9 @@ import javax.xml.parsers.ParserConfigurationException;
 */
 public class ApiLddsClient extends ApiBasicClient
 {
+	/** Logger for the class **/
+	private static final Logger LOGGER = LoggerFactory.getLogger(ApiLddsClient.class);
+	
 	/** Input stream coming from the server */
 	private LddsInputStream linput;
 
@@ -651,17 +655,17 @@ debug(module + ".sendAuthHello authenticator '" + authStr + "'");
 
 	public void info(String str)
 	{
-		LoggerFactory.getLogger(ApiConstants.loggerName).info("LddsClient INFO: {}", str);
+		LOGGER.info("LddsClient INFO: {}", str);
 	}
 	
 	private void debug(String str)
 	{
-		LoggerFactory.getLogger(ApiConstants.loggerName).trace("LddsClient DEBUG: {}", str);
+		LOGGER.trace("LddsClient DEBUG: {}", str);
 	}
 	
 	private void warning(String str)
 	{
-		LoggerFactory.getLogger(ApiConstants.loggerName).warn("LddsClient WARNING: {}", str);
+		LOGGER.warn("LddsClient WARNING: {}", str);
 	}
 
 	public long getLastActivity()

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/ApiLddsClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/ApiLddsClient.java
@@ -27,6 +27,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 
@@ -535,9 +536,8 @@ debug(module + ".sendAuthHello authenticator '" + authStr + "'");
 		}
 		catch(Exception ex)
 		{
-			String em = "Error in LrgsStatusXio: " + ex;
-			warning(em);
-			throw new DdsProtocolError(em);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING, "Error in LrgsStatusXio: %s", ex);
+			throw new DdsProtocolError(ex.getMessage());
 		}
 	}
 
@@ -598,9 +598,8 @@ debug(module + ".sendAuthHello authenticator '" + authStr + "'");
 		}
 		catch(Exception ex)
 		{
-			String em = "Error in RawMessageBlockParser: " + ex;
-			warning(em);
-			throw new DdsProtocolError(em);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING, "Error in RawMessageBlockParser: %s", ex);
+			throw new DdsProtocolError(ex.getMessage());
 		}
 	}
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/DdsProtocolError.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/lrgsclient/DdsProtocolError.java
@@ -35,6 +35,11 @@ public class DdsProtocolError extends Exception
 		super(msg);
 	}
 
+	public DdsProtocolError(String msg, Throwable throwable)
+	{
+		super(msg, throwable);
+	}
+
 	/** @return string representation of this exception. */
 	public String toString()
 	{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
@@ -272,25 +272,16 @@ Logger.getLogger(ApiConstants.loggerName).info("   parm '" + dcp.getRoleName() +
 			throw new WebAppException(ErrorCodes.BAD_CONFIG, 
 				"Specified triggering time series does not exist in the database: " + ex);
 		}
-		catch (BadTimeSeriesException ex)
+		catch (BadTimeSeriesException | DuplicateTimeSeriesException ex)
 		{
-			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING, "Error in RawMessageBlockParser: %s", ex);
-			throw new WebAppException(500, ex.getMessage());
-		}
-		catch (DuplicateTimeSeriesException ex)
-		{
-			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
-					"Unexpected DuplicateTimeSeriesException: %s", ex);
-			throw new WebAppException(500, ex.getMessage());
+			throw new WebAppException(500, ex.getMessage(), ex);
 		}
 		catch (DbCompException ex)
 		{
-			throw new WebAppException(ErrorCodes.BAD_CONFIG, "Error in computation exec: " + ex);
+			throw new WebAppException(ErrorCodes.BAD_CONFIG, "Error in computation exec: ", ex);
 		}
 		catch (DbIoException ex)
 		{
-			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
-					"testComp error from tsdb interface: %s", ex);
 			throw new DbException(module, ex, "testComp error from tsdb interface");
 		}
 		finally

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
@@ -274,16 +274,12 @@ Logger.getLogger(ApiConstants.loggerName).info("   parm '" + dcp.getRoleName() +
 		{
 			String emsg = "Unexpected BadTimeSeriesException: " + ex;
 			Logger.getLogger(ApiConstants.loggerName).warning(emsg);
-			System.out.println(emsg);
-			ex.printStackTrace();
 			throw new WebAppException(500, emsg);
 		}
 		catch (DuplicateTimeSeriesException ex)
 		{
 			String emsg = "Unexpected DuplicateTimeSeriesException: " + ex;
 			Logger.getLogger(ApiConstants.loggerName).warning(emsg);
-			System.out.println(emsg);
-			ex.printStackTrace();
 			throw new WebAppException(500, emsg);
 		}
 		catch (DbCompException ex)
@@ -294,7 +290,6 @@ Logger.getLogger(ApiConstants.loggerName).info("   parm '" + dcp.getRoleName() +
 		{
 			String msg = module + ".testComp error from tsdb interface: " + ex;
 			Logger.getLogger(ApiConstants.loggerName).warning(msg);
-			ex.printStackTrace();
 			throw new DbException(module, ex, msg);
 		}
 		finally

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
@@ -275,13 +275,13 @@ Logger.getLogger(ApiConstants.loggerName).info("   parm '" + dcp.getRoleName() +
 		catch (BadTimeSeriesException ex)
 		{
 			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING, "Error in RawMessageBlockParser: %s", ex);
-			throw new WebAppException(500, String.format("Error in RawMessageBlockParser: %s", ex));
+			throw new WebAppException(500, ex.getMessage());
 		}
 		catch (DuplicateTimeSeriesException ex)
 		{
 			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
 					"Unexpected DuplicateTimeSeriesException: %s", ex);
-			throw new WebAppException(500, String.format("Unexpected DuplicateTimeSeriesException: %s", ex));
+			throw new WebAppException(500, ex.getMessage());
 		}
 		catch (DbCompException ex)
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/CompRunner.java
@@ -57,6 +57,8 @@ import decodes.tsdb.TimeSeriesIdentifier;
 import decodes.tsdb.TsGroup;
 import decodes.tsdb.TsGroupMember;
 import decodes.tsdb.VarFlags;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import opendcs.dai.AlgorithmDAI;
 import opendcs.dai.DataTypeDAI;
@@ -272,15 +274,14 @@ Logger.getLogger(ApiConstants.loggerName).info("   parm '" + dcp.getRoleName() +
 		}
 		catch (BadTimeSeriesException ex)
 		{
-			String emsg = "Unexpected BadTimeSeriesException: " + ex;
-			Logger.getLogger(ApiConstants.loggerName).warning(emsg);
-			throw new WebAppException(500, emsg);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING, "Error in RawMessageBlockParser: %s", ex);
+			throw new WebAppException(500, String.format("Error in RawMessageBlockParser: %s", ex));
 		}
 		catch (DuplicateTimeSeriesException ex)
 		{
-			String emsg = "Unexpected DuplicateTimeSeriesException: " + ex;
-			Logger.getLogger(ApiConstants.loggerName).warning(emsg);
-			throw new WebAppException(500, emsg);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
+					"Unexpected DuplicateTimeSeriesException: %s", ex);
+			throw new WebAppException(500, String.format("Unexpected DuplicateTimeSeriesException: %s", ex));
 		}
 		catch (DbCompException ex)
 		{
@@ -288,9 +289,9 @@ Logger.getLogger(ApiConstants.loggerName).info("   parm '" + dcp.getRoleName() +
 		}
 		catch (DbIoException ex)
 		{
-			String msg = module + ".testComp error from tsdb interface: " + ex;
-			Logger.getLogger(ApiConstants.loggerName).warning(msg);
-			throw new DbException(module, ex, msg);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
+					"testComp error from tsdb interface: %s", ex);
+			throw new DbException(module, ex, "testComp error from tsdb interface");
 		}
 		finally
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/TsdbManager.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/TsdbManager.java
@@ -15,20 +15,14 @@
 
 package org.opendcs.odcsapi.opendcs_dep;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.logging.Logger;
-
 import org.opendcs.odcsapi.dao.DbException;
 import org.opendcs.odcsapi.hydrojson.DbInterface;
-import org.opendcs.odcsapi.util.ApiConstants;
 
 import decodes.cwms.CwmsTimeSeriesDb;
 import decodes.hdb.HdbTimeSeriesDb;
 import decodes.tsdb.BadConnectException;
 import decodes.tsdb.TimeSeriesDb;
 import opendcs.opentsdb.OpenTsdb;
-import opendcs.opentsdb.OpenTsdbSettings;
 
 /**
  * A few operations require using the openDCS TimeSeriesDb subclasses.
@@ -60,25 +54,18 @@ public class TsdbManager
 			ret = new HdbTimeSeriesDb();
 		else
 			ret = new OpenTsdb();
-		
-		ret.setConnection(dbi.getConnection());
-		
+
 		// setConnection will also call determineTsdbVersion()
-		
-		// ret.setupKeyGenerator(); - No need, the API will not use Tsdb to create records.
+		ret.setConnection(dbi.getConnection());
 
 		try
 		{
 			ret.postConnectInit("decodes", dbi.getConnection());
 		}
-		catch (BadConnectException e)
+		catch (BadConnectException ex)
 		{
-			Logger.getLogger(ApiConstants.loggerName).info("Using DataSource provided by Jetty main class.");
-
-			e.printStackTrace();
+			throw new DbException(CompRunner.class.getName(), ex, "Error connecting to the decodes database: ");
 		}
-
-		// OpenTsdbSettings.instance().setFromProperties(props); - No need. Use defaults.
 
 		return ret;
 	}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -309,9 +309,8 @@ System.out.println("Connected to " + appStat.getHostname() + ":" + port);
 		}
 		catch (IOException ex)
 		{
-			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
-					String.format("Error attempting to start appId=%s: %s", appId, ex));
-			throw new WebAppException(ErrorCodes.DATABASE_ERROR, ex.getMessage());
+			throw new WebAppException(ErrorCodes.DATABASE_ERROR,
+					String.format("Error attempting to start appId=%s", appId), ex);
 		}
 	}
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -308,9 +308,9 @@ System.out.println("Connected to " + appStat.getHostname() + ":" + port);
 		}
 		catch (IOException ex)
 		{
-			ex.printStackTrace();
-			throw new WebAppException(ErrorCodes.DATABASE_ERROR,
-				"Error attempting to start appId=" + appId + ": " + ex);
+			String message = "Error attempting to start appId=" + appId + ": " + ex;
+			Logger.getLogger(ApiConstants.loggerName).warning(message);
+			throw new WebAppException(ErrorCodes.DATABASE_ERROR, message);
 		}
 	}
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
@@ -308,9 +309,9 @@ System.out.println("Connected to " + appStat.getHostname() + ":" + port);
 		}
 		catch (IOException ex)
 		{
-			String message = "Error attempting to start appId=" + appId + ": " + ex;
-			Logger.getLogger(ApiConstants.loggerName).warning(message);
-			throw new WebAppException(ErrorCodes.DATABASE_ERROR, message);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.WARNING,
+					String.format("Error attempting to start appId=%s: %s", appId, ex));
+			throw new WebAppException(ErrorCodes.DATABASE_ERROR, ex.getMessage());
 		}
 	}
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/LrgsResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/LrgsResources.java
@@ -192,8 +192,9 @@ public class LrgsResources
 			{
 				client.disconnect();
 				userToken.setLddsClient(null);
-				e.printStackTrace();
-				throw new WebAppException(ErrorCodes.DATABASE_ERROR, "Internal exception:" + e);
+				String errmsg = "Internal exception:" + e;
+				Logger.getLogger(ApiConstants.loggerName).severe(errmsg);
+				throw new WebAppException(ErrorCodes.DATABASE_ERROR, errmsg);
 			}
 			catch (UnknownHostException ex)
 			{
@@ -401,8 +402,9 @@ public class LrgsResources
 		}
 		catch (DbException e)
 		{
-			e.printStackTrace();
-			throw new WebAppException(ErrorCodes.DATABASE_ERROR, "Internal exception:" + e);
+			String errmsg = "Internal exception:" + e;
+			Logger.getLogger(ApiConstants.loggerName).severe(errmsg);
+			throw new WebAppException(ErrorCodes.DATABASE_ERROR, errmsg);
 		}
 		catch (UnknownHostException ex)
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/LrgsResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/LrgsResources.java
@@ -189,12 +189,12 @@ public class LrgsResources
 				action = "sending searchcrit";
 				client.sendSearchCrit(searchcrit, platformDao);
 			}
-			catch (DbException e)
+			catch (DbException ex)
 			{
 				client.disconnect();
 				userToken.setLddsClient(null);
-				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Internal exception: ", e);
-				throw new WebAppException(ErrorCodes.DATABASE_ERROR, e.getMessage());
+				throw new WebAppException(ErrorCodes.DATABASE_ERROR,
+						"There was an error getting messages from the LRGS client: ", ex);
 			}
 			catch (UnknownHostException ex)
 			{
@@ -400,32 +400,25 @@ public class LrgsResources
 			action = "getting LRGS status";
 			return ApiHttpUtil.createResponse(client.getLrgsStatus());
 		}
-		catch (DbException e)
+		catch (DbException ex)
 		{
-			Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Internal exception: ", e);
-			throw new WebAppException(ErrorCodes.DATABASE_ERROR, e.getMessage());
+			throw new WebAppException(ErrorCodes.DATABASE_ERROR,
+					"There was an error connecting to the decodes database", ex);
 		}
 		catch (UnknownHostException ex)
 		{
 			throw new WebAppException(ErrorCodes.BAD_CONFIG, "Cannot connect to LRGS data source "
-				+ dataSource.getName() + ": " + ex);
+				+ dataSource.getName() + ": ", ex);
 		}
 		catch (IOException ex)
 		{
 			throw new WebAppException(ErrorCodes.BAD_CONFIG, "IO Error on LRGS data source "
-				+ dataSource.getName() + ": " + ex);
+				+ dataSource.getName() + ": ", ex);
 		}
-		catch (DdsProtocolError ex)
+		catch (DdsProtocolError | DdsServerError ex)
 		{
-			String em = "Error while " + action + ": " + ex;
-			Logger.getLogger(ApiConstants.loggerName).warning("getMessages " + em);
-			throw new WebAppException(ErrorCodes.IO_ERROR, em);
-		}
-		catch (DdsServerError ex)
-		{
-			String em = "Error while " + action + ": " + ex;
-			Logger.getLogger(ApiConstants.loggerName).warning("getMessages " + em);
-			throw new WebAppException(ErrorCodes.IO_ERROR, em);
+			String em = "Error while " + action + ": ";
+			throw new WebAppException(ErrorCodes.IO_ERROR, em, ex);
 		}
 		finally
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/LrgsResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/LrgsResources.java
@@ -20,6 +20,7 @@ import java.net.UnknownHostException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
@@ -192,9 +193,8 @@ public class LrgsResources
 			{
 				client.disconnect();
 				userToken.setLddsClient(null);
-				String errmsg = "Internal exception:" + e;
-				Logger.getLogger(ApiConstants.loggerName).severe(errmsg);
-				throw new WebAppException(ErrorCodes.DATABASE_ERROR, errmsg);
+				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Internal exception: ", e);
+				throw new WebAppException(ErrorCodes.DATABASE_ERROR, e.getMessage());
 			}
 			catch (UnknownHostException ex)
 			{
@@ -402,9 +402,8 @@ public class LrgsResources
 		}
 		catch (DbException e)
 		{
-			String errmsg = "Internal exception:" + e;
-			Logger.getLogger(ApiConstants.loggerName).severe(errmsg);
-			throw new WebAppException(ErrorCodes.DATABASE_ERROR, errmsg);
+			Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Internal exception: ", e);
+			throw new WebAppException(ErrorCodes.DATABASE_ERROR, e.getMessage());
 		}
 		catch (UnknownHostException ex)
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
@@ -142,12 +142,12 @@ public class ApiBasicClient
 	{
 		try
 		{
+			if (socket != null)
+				socket.close();
 			if (input != null)
 				input.close();
 			if (output != null)
 				output.close();
-			if (socket != null)
-				socket.close();
 			LOGGER.debug("Disconnected form host '{}', port {}", (host != null ? host : "(unknown)"), port);
 		}
 		catch (IOException ex)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
@@ -18,8 +18,9 @@ package org.opendcs.odcsapi.util;
 import java.net.*;
 import java.io.*;
 import java.rmi.UnknownHostException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
 This class encapsulates common functions for a TCP/IP client.
@@ -28,6 +29,7 @@ object of this type.
 */
 public class ApiBasicClient
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ApiBasicClient.class);
 	/** port to connect to. */
 	protected int port;
 	/** host to connect to. */
@@ -68,7 +70,7 @@ public class ApiBasicClient
 	* Finalizer makes sure socket and stream resources are freed. If
 	* disconnect() was already called, no harm done.
 	*/
-	protected void finalize( )
+	protected void finalize( ) throws IOException
 	{
 		disconnect();
 	}
@@ -140,40 +142,18 @@ public class ApiBasicClient
 	{
 		try
 		{
-			try
-			{
-				if (input != null)
-					input.close();
-			}
-			catch (IOException ex)
-			{
-				throw new IOException("Error closing input: ", ex);
-			}
-            try
-			{
-                if (output != null)
-                    output.close();
-            }
-			catch (IOException ex)
-			{
-				throw new IOException("Error closing output: ", ex);
-            }
-			try
-			{
-				if (socket != null)
-					socket.close();
-			}
-			catch (IOException ex)
-			{
-				throw new IOException( "Error closing socket: ", ex);
-			}
-
-			if (debug != null)
-				debug.println("Disconnected form host '"
-					+ (host != null ? host : "(unknown)")
-					+ "', port " + port);
+			if (input != null)
+				input.close();
+			if (output != null)
+				output.close();
+			if (socket != null)
+				socket.close();
+			LOGGER.debug("Disconnected form host '{}', port {}", (host != null ? host : "(unknown)"), port);
 		}
-		catch(Exception e) {}
+		catch (IOException ex)
+		{
+			LOGGER.error("There was an error closing the socket connections.", ex);
+		}
 		finally
 		{
 			input = null;

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
@@ -145,27 +145,27 @@ public class ApiBasicClient
 				if (input != null)
 					input.close();
 			}
-			catch (Exception e)
+			catch (IOException ex)
 			{
-				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Error closing input: ", e);
+				throw new IOException("Error closing input: ", ex);
 			}
-			try
+            try
 			{
-				if (output != null)
-					output.close();
-			}
-			catch (Exception e)
+                if (output != null)
+                    output.close();
+            }
+			catch (IOException ex)
 			{
-				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Error closing output: ", e);
-			}
+				throw new IOException("Error closing output: ", ex);
+            }
 			try
 			{
 				if (socket != null)
 					socket.close();
 			}
-			catch (Exception e)
+			catch (IOException ex)
 			{
-				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Error closing socket: ", e);
+				throw new IOException( "Error closing socket: ", ex);
 			}
 
 			if (debug != null)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
@@ -18,6 +18,7 @@ package org.opendcs.odcsapi.util;
 import java.net.*;
 import java.io.*;
 import java.rmi.UnknownHostException;
+import java.util.logging.Logger;
 
 /**
 This class encapsulates common functions for a TCP/IP client.
@@ -145,8 +146,7 @@ public class ApiBasicClient
 			}
 			catch (Exception e)
 			{
-				System.out.println("Error closing input: "+e.getMessage());
-				e.printStackTrace();
+				Logger.getLogger(ApiConstants.loggerName).severe("Error closing input: " + e);
 			}
 			try
 			{
@@ -155,8 +155,7 @@ public class ApiBasicClient
 			}
 			catch (Exception e)
 			{
-				System.out.println("Error closing ouput: "+e.getMessage());
-				e.printStackTrace();
+				Logger.getLogger(ApiConstants.loggerName).severe("Error closing output: " + e);
 			}
 			try
 			{
@@ -165,8 +164,7 @@ public class ApiBasicClient
 			}
 			catch (Exception e)
 			{
-				System.out.println("Error closing socket: "+e.getMessage());
-				e.printStackTrace();
+				Logger.getLogger(ApiConstants.loggerName).severe("Error closing socket: " + e);
 			}
 
 			if (debug != null)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/util/ApiBasicClient.java
@@ -18,6 +18,7 @@ package org.opendcs.odcsapi.util;
 import java.net.*;
 import java.io.*;
 import java.rmi.UnknownHostException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -146,7 +147,7 @@ public class ApiBasicClient
 			}
 			catch (Exception e)
 			{
-				Logger.getLogger(ApiConstants.loggerName).severe("Error closing input: " + e);
+				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Error closing input: ", e);
 			}
 			try
 			{
@@ -155,7 +156,7 @@ public class ApiBasicClient
 			}
 			catch (Exception e)
 			{
-				Logger.getLogger(ApiConstants.loggerName).severe("Error closing output: " + e);
+				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Error closing output: ", e);
 			}
 			try
 			{
@@ -164,7 +165,7 @@ public class ApiBasicClient
 			}
 			catch (Exception e)
 			{
-				Logger.getLogger(ApiConstants.loggerName).severe("Error closing socket: " + e);
+				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,"Error closing socket: ", e);
 			}
 
 			if (debug != null)

--- a/opendcs-web-client/build.gradle
+++ b/opendcs-web-client/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation(libs.jetty.jsp)
     implementation(libs.servlet.api)
     implementation(libs.websocket)
+    implementation(libs.slf4j.jdk)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.junit.jupiter)
 }

--- a/opendcs-web-client/src/main/java/api/Gateway.java
+++ b/opendcs-web-client/src/main/java/api/Gateway.java
@@ -35,6 +35,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
@@ -68,10 +69,13 @@ public class Gateway extends HttpServlet {
      */
     public void init() throws ServletException {
         System.out.println("Initializing the Gateway instance.");
-        try {
+        try
+        {
             this.setApiDetails(null);
-        } catch (IOException e) {
-            e.printStackTrace();
+        }
+        catch (IOException e)
+        {
+            Logger.getLogger(Gateway.class.getName()).severe("Error completing request: " + e);
         }
     }    
 
@@ -308,8 +312,10 @@ public class Gateway extends HttpServlet {
                 System.out.println(String.format("Error: %s.", inline));
             }
 
-        } catch (Exception e) {
-            e.printStackTrace();
+        }
+        catch (Exception e)
+        {
+            Logger.getLogger(Gateway.class.getName()).severe("Error completing request: " + e);
             response.setStatus(400);
             inline = "error";
         }

--- a/opendcs-web-client/src/main/java/api/Gateway.java
+++ b/opendcs-web-client/src/main/java/api/Gateway.java
@@ -68,15 +68,16 @@ public class Gateway extends HttpServlet {
      *
      * @throws ServletException 
      */
-    public void init() throws ServletException {
+    public void init() throws ServletException
+    {
         System.out.println("Initializing the Gateway instance.");
         try
         {
             this.setApiDetails(null);
         }
-        catch (IOException e)
+        catch (IOException ex)
         {
-            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE, "Error completing request: ", e);
+            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE, "Error initializing gateway instance: ", ex);
         }
     }    
 
@@ -312,11 +313,11 @@ public class Gateway extends HttpServlet {
                 inline = "{\"message\": \"error - you must pass the opendcs_api_call parameter.\"}";
                 System.out.println(String.format("Error: %s.", inline));
             }
-
         }
-        catch (Exception e)
+        catch (IOException ex)
         {
-            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE,"Error completing request: ", e);
+            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE,
+                    "Error connecting to API from gateway: ", ex);
             response.setStatus(400);
             inline = "error";
         }

--- a/opendcs-web-client/src/main/java/api/Gateway.java
+++ b/opendcs-web-client/src/main/java/api/Gateway.java
@@ -35,6 +35,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -75,7 +76,7 @@ public class Gateway extends HttpServlet {
         }
         catch (IOException e)
         {
-            Logger.getLogger(Gateway.class.getName()).severe("Error completing request: " + e);
+            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE, "Error completing request: ", e);
         }
     }    
 
@@ -315,7 +316,7 @@ public class Gateway extends HttpServlet {
         }
         catch (Exception e)
         {
-            Logger.getLogger(Gateway.class.getName()).severe("Error completing request: " + e);
+            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE,"Error completing request: ", e);
             response.setStatus(400);
             inline = "error";
         }

--- a/opendcs-web-client/src/main/java/api/Gateway.java
+++ b/opendcs-web-client/src/main/java/api/Gateway.java
@@ -35,8 +35,9 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
@@ -56,6 +57,7 @@ import javax.websocket.Session;
  */
 public class Gateway extends HttpServlet {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Gateway.class);
 
     /**
      * The base url for the API to get OpenDCS data from.
@@ -70,14 +72,13 @@ public class Gateway extends HttpServlet {
      */
     public void init() throws ServletException
     {
-        System.out.println("Initializing the Gateway instance.");
         try
         {
             this.setApiDetails(null);
         }
         catch (IOException ex)
         {
-            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE, "Error initializing gateway instance: ", ex);
+            LOGGER.error("Error initializing gateway instance", ex);
         }
     }    
 
@@ -316,8 +317,7 @@ public class Gateway extends HttpServlet {
         }
         catch (IOException ex)
         {
-            Logger.getLogger(Gateway.class.getName()).log(Level.SEVERE,
-                    "Error connecting to API from gateway: ", ex);
+            LOGGER.error("Error connecting to API from gateway: ", ex);
             response.setStatus(400);
             inline = "error";
         }


### PR DESCRIPTION
## Problem Description
There are several calls to throwable.printStackTrace throughout the rest-api project.  These have been flagged as insecure and need to be removed.
Fixes #96. 
Throwable.printStackTrace(...) prints a Throwable and its stack trace to System.Err (by default) which is not easily parseable and can expose sensitive information.

## Solution
Use a logger to get the same message to the user.

## how you tested the change
Forced one of these conditions and verified the logger logged the message.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
