### PR TITLE
use the github gradle build action in order to get the dependency graph to work

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 permissions:
-  checks: write
+  contents: write
 jobs:
   build:
     name: Build, Test, and Analyze
@@ -27,12 +27,10 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Gradle packages
-        uses: actions/cache@v3.3.3
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.9.0
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          dependency-graph: generate-and-submit
       - name: Build
         run: ./gradlew build
       - name: Analyze

--- a/.github/workflows/java_compatibility.yml
+++ b/.github/workflows/java_compatibility.yml
@@ -22,11 +22,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: Cache Gradle packages
-        uses: actions/cache@v3.3.3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.9.0
       - name: Compile and Test
         run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,8 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-      - name: Cache Gradle packages
-        uses: actions/cache@v3.3.3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.9.0
       - name: Build
         run: ./gradlew build
       - name: Bundle tarballs


### PR DESCRIPTION
this will include the ability to download an SBOM as well as performs the caching (which we were doing separately already)

## Problem Description

The GitHub Dependency Graph is automatically populated in a gradle environment.
Fixes #41 

## Solution

Add the GitHub action for gradle with the settings for upload the dependency graph.

## how you tested the change

Tested in the main branch of my fork

## Where the following done:

- [X] Were relevant config element (e.g. XML data) updated as appropriate

