### PR TITLE
set the current version to after the last git tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,16 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
             property "sonar.host.url", "https://sonarcloud.io"
             property "sonar.pullrequest.provider", "GitHub"
             property "sonar.pullrequest.github.repository", "opendcs/rest_api"
+            property "sonar.projectVersion", sonarVersion()
         }
     }
+}
+
+ext.sonarVersion = {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--abbrev=0', "--always"
+        standardOutput = stdout
+    }
+    return stdout.toString().trim() + "+"
 }


### PR DESCRIPTION
## Problem Description

SonarCloud doesn't know what the last version of the software is. It cannot determine what the "New Code" period is with it

## Solution

Always set the current version to the last tag but with "+" at the end.

## how you tested the change

Testing post-merge

## Where the following done:

- [X] Were relevant config element (e.g. XML data) updated as appropriate

