### PR TITLE
Dynamically created sql using sequence name as a variable.

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiAlgorithmDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiAlgorithmDAO.java
@@ -207,7 +207,7 @@ public class ApiAlgorithmDAO
 	private void insert(ApiAlgorithm algo)
 		throws DbException
 	{
-		algo.setAlgorithmId(getKey("CP_ALGORITHM"));
+		algo.setAlgorithmId(getKey(DbInterface.Sequences.CP_ALGORITHM));
 		
 		q = "insert into CP_ALGORITHM(algorithm_id, algorithm_name, "
 			+ "exec_class, cmmnt) "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiAppDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiAppDAO.java
@@ -184,7 +184,7 @@ public class ApiAppDAO
 			app.setLastModified(new Date());
 			if (app.getAppId() == null)
 			{
-				app.setAppId(getKey("HDB_LOADING_APPLICATION"));
+				app.setAppId(getKey(DbInterface.Sequences.HDB_LOADING_APPLICATION));
 	
 				q = "insert into HDB_LOADING_APPLICATION(LOADING_APPLICATION_ID,"
 					+ " LOADING_APPLICATION_NAME, MANUAL_EDIT_APP, CMMNT) values (?, ?, ?, ?)";

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiComputationDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiComputationDAO.java
@@ -609,7 +609,7 @@ public class ApiComputationDAO
 	private void insert(ApiComputation comp)
 		throws DbException
 	{
-		comp.setComputationId(getKey("CP_COMPUTATION"));
+		comp.setComputationId(getKey(DbInterface.Sequences.CP_COMPUTATION));
 		comp.setLastModified(new Date());
 		
 		String q = "insert into CP_COMPUTATION(computation_id, computation_name, "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiConfigDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiConfigDAO.java
@@ -330,7 +330,7 @@ public class ApiConfigDAO
 	private void insert(ApiPlatformConfig config)
 			throws DbException, SQLException
 	{
-		config.setConfigId(getKey("PLATFORMCONFIG"));
+		config.setConfigId(getKey(DbInterface.Sequences.PLATFORMCONFIG));
 
 		String q = "insert into PLATFORMCONFIG(ID, NAME, DESCRIPTION)"
 			+ " values (?, ?, ?)";
@@ -450,7 +450,7 @@ public class ApiConfigDAO
 		
 		for(ApiConfigScript acs : config.getScripts())
 		{
-			long scriptId = getKey("DECODESSCRIPT");
+			long scriptId = getKey(DbInterface.Sequences.DECODESSCRIPT);
 			String q = "insert into DECODESSCRIPT(ID, CONFIGID, NAME, SCRIPT_TYPE, DATAORDER)"
 				+ " values(?, ?, ?, ?, ?)";
 			doModifyV(q, scriptId, config.getConfigId(), acs.getName(), acs.getHeaderType(), acs.getDataOrder());
@@ -465,7 +465,7 @@ public class ApiConfigDAO
 			
 			for(ApiConfigScriptSensor acss : acs.getScriptSensors())
 			{
-				long ucid = getKey("UNITCONVERTER");
+				long ucid = getKey(DbInterface.Sequences.UNITCONVERTER);
 				
 				q = "insert into UNITCONVERTER(ID, FROMUNITSABBR, TOUNITSABBR, ALGORITHM, "
 					+ "A, B, C, D, E, F) values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaiBase.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaiBase.java
@@ -15,6 +15,8 @@
 
 package org.opendcs.odcsapi.dao;
 
+import org.opendcs.odcsapi.hydrojson.DbInterface;
+
 import java.sql.ResultSet;
 
 public interface ApiDaiBase
@@ -31,6 +33,6 @@ public interface ApiDaiBase
 
 	public void close();
 	
-	public Long getKey(String tableName)
+	public Long getKey(DbInterface.Sequences sequenceName)
 		throws DbException;
 }

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaiBase.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaiBase.java
@@ -22,17 +22,17 @@ import java.sql.ResultSet;
 public interface ApiDaiBase
 	extends AutoCloseable
 {
-	public ResultSet doQuery(String q)
+	ResultSet doQuery(String q)
 		throws DbException;
 	
-	public ResultSet doQuery2(String q) 
+	ResultSet doQuery2(String q)
 		throws DbException;
 
-	public int doModify(String q)
+	int doModify(String q)
 		throws DbException;
 
-	public void close();
+	void close();
 	
-	public Long getKey(DbInterface.Sequences sequenceName)
+	Long getKey(DbInterface.Sequences sequenceName)
 		throws DbException;
 }

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaoBase.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaoBase.java
@@ -232,12 +232,12 @@ public class ApiDaoBase
 		return "'" + a + "'";
 	}
 
-	public Long getKey(String tableName)
+	public Long getKey(DbInterface.Sequences sequenceName)
 			throws DbException
 	{
 		try
 		{
-			return dbi.getKey(tableName);
+			return dbi.getKey(sequenceName);
 		} catch (SQLException e)
 		{
 			throw new DbException(e.getMessage());

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaoBase.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaoBase.java
@@ -233,9 +233,15 @@ public class ApiDaoBase
 	}
 
 	public Long getKey(String tableName)
-		throws DbException
+			throws DbException
 	{
-		return dbi.getKey(tableName);
+		try
+		{
+			return dbi.getKey(tableName);
+		} catch (SQLException e)
+		{
+			throw new DbException(e.getMessage());
+		}
 	}
 	
 	/**

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaoBase.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDaoBase.java
@@ -238,9 +238,10 @@ public class ApiDaoBase
 		try
 		{
 			return dbi.getKey(sequenceName);
-		} catch (SQLException e)
+		}
+		catch (DbException | SQLException ex)
 		{
-			throw new DbException(e.getMessage());
+			throw new DbException(module, ex, "There was an issue getting the sequence from the database");
 		}
 	}
 	

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDataSourceDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDataSourceDAO.java
@@ -179,7 +179,7 @@ public class ApiDataSourceDAO extends ApiDaoBase
 
 			if (ds.getDataSourceId() == null)
 			{
-				ds.setDataSourceId(getKey("DATASOURCE"));
+				ds.setDataSourceId(getKey(DbInterface.Sequences.DATASOURCE));
 				insert(ds);
 			}
 			else
@@ -213,7 +213,7 @@ public class ApiDataSourceDAO extends ApiDaoBase
 	private void insert(ApiDataSource ds)
 		throws DbException
 	{
-		Long id = getKey("DataSource");
+		Long id = getKey(DbInterface.Sequences.DATASOURCE);
 		ds.setDataSourceId(id);
 		String args = ApiPropertiesUtil.props2string(ds.getProps());
 		String q = "INSERT INTO DataSource(id, name, datasourcetype, datasourcearg) "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDataTypeDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiDataTypeDAO.java
@@ -69,7 +69,7 @@ public class ApiDataTypeDAO
 	public long create(String std, String code)
 		throws DbException
 	{
-		Long id = getKey("DATATYPE");
+		Long id = getKey(DbInterface.Sequences.DATATYPE);
 		String q = "insert into DATATYPE(ID, STANDARD, CODE) values (?, ?, ?)";
 		doModifyV(q, id, std, code);
 		return id;

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiNetlistDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiNetlistDAO.java
@@ -222,7 +222,7 @@ public class ApiNetlistDAO
 	private void insert(ApiNetList netlist)
 		throws DbException
 	{
-		netlist.setNetlistId(getKey("NETWORKLIST"));
+		netlist.setNetlistId(getKey(DbInterface.Sequences.NETWORKLIST));
 		String q = "insert into NETWORKLIST(ID, NAME, TRANSPORTMEDIUMTYPE, "
 			+ "SITENAMETYPEPREFERENCE, LASTMODIFYTIME) values (?, ?, ?, ?, ?)";
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiPlatformDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiPlatformDAO.java
@@ -467,7 +467,7 @@ public class ApiPlatformDAO
 	private void insert(ApiPlatform platform)
 		throws DbException, WebAppException
 	{
-		platform.setPlatformId(getKey("PLATFORM"));
+		platform.setPlatformId(getKey(DbInterface.Sequences.PLATFORM));
 		q = "insert into PLATFORM(ID, AGENCY, ISPRODUCTION, SITEID, CONFIGID, DESCRIPTION"
 				+ ", LASTMODIFYTIME, PLATFORMDESIGNATOR)"
 			+ " values (?, ?, ?, ?, ?, ?, ?, ?)";

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiPresentationDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiPresentationDAO.java
@@ -194,7 +194,7 @@ public class ApiPresentationDAO
 	private void insert(ApiPresentationGroup presGrp)
 		throws DbException, SQLException
 	{
-		presGrp.setGroupId(getKey("PRESENTATIONGROUP"));
+		presGrp.setGroupId(getKey(DbInterface.Sequences.PRESENTATIONGROUP));
 
 		String q = "insert into PRESENTATIONGROUP(ID, NAME, INHERITSFROM, LASTMODIFYTIME, ISPRODUCTION)"
 			+ " values(?, ?, ?, ?, ?)";
@@ -216,7 +216,7 @@ public class ApiPresentationDAO
 				Long dtId = dtDao.lookup(dpe.getDataTypeStd(), dpe.getDataTypeCode());
 				if (dtId == null)
 					dtId = dtDao.create(dpe.getDataTypeStd(), dpe.getDataTypeCode());
-				long id = this.getKey("DATAPRESENTATION");
+				long id = this.getKey(DbInterface.Sequences.DATAPRESENTATION);
 				String q = "insert into DATAPRESENTATION(ID, GROUPID, DATATYPEID, UNITABBR, "
 					+ "MAXDECIMALS, MAX_VALUE, MIN_VALUE) values (?, ?, ?, ?, ?, ?, ?)";
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiRefListDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiRefListDAO.java
@@ -155,7 +155,7 @@ public class ApiRefListDAO extends ApiDaoBase
 			//insert
 			String q = "insert into INTERVAL_CODE(INTERVAL_ID, NAME, CAL_CONSTANT, CAL_MULTIPLIER)"
 				+ " values(?,?,?,?)";
-			intv.setIntervalId(getKey("INTERVAL_CODE"));
+			intv.setIntervalId(getKey(DbInterface.Sequences.INTERVAL_CODE));
 			doModifyV(q, intv.getIntervalId(), intv.getName(), intv.getCalConstant(), 
 				(Integer)intv.getCalMultilier());
 		}
@@ -226,7 +226,7 @@ public class ApiRefListDAO extends ApiDaoBase
 			arl.setReflistId(this.lookupId(q, arl.getEnumName()));
 			if (arl.getReflistId() == null)
 				// Still no ID, assume this is a new ENUM.
-				arl.setReflistId(getKey("ENUM"));
+				arl.setReflistId(getKey(DbInterface.Sequences.ENUM));
 		}
 		ApiRefList oldlist = getRefList(arl.getReflistId());
 		if (oldlist == null)
@@ -358,7 +358,7 @@ public class ApiRefListDAO extends ApiDaoBase
 		catch(WebAppException ex)
 		{
 			// This can only mean that there is no "season" enumeration. Create it.
-			seasonRlId = getKey("ENUM");
+			seasonRlId = getKey(DbInterface.Sequences.ENUM);
 			
 			String q = "insert into ENUM(ID, NAME, DEFAULTVALUE, DESCRIPTION)"
 					+ " values(?, ?, ?, ?)";

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiRoutingDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiRoutingDAO.java
@@ -295,7 +295,7 @@ public class ApiRoutingDAO
 	private void insert(ApiRouting routing)
 		throws DbException
 	{
-		routing.setRoutingId(getKey("ROUTINGSPEC"));
+		routing.setRoutingId(getKey(DbInterface.Sequences.ROUTINGSPEC));
 
 		String q = "insert into ROUTINGSPEC(ID, NAME, DATASOURCEID, ENABLEEQUATIONS, "
 				+ "OUTPUTFORMAT, OUTPUTTIMEZONE, PRESENTATIONGROUPNAME,"
@@ -528,7 +528,7 @@ public class ApiRoutingDAO
 			
 			if (schedule.getSchedEntryId() == null)
 			{
-				schedule.setSchedEntryId(getKey("SCHEDULE_ENTRY"));
+				schedule.setSchedEntryId(getKey(DbInterface.Sequences.SCHEDULE_ENTRY));
 	
 				q = "insert into SCHEDULE_ENTRY(SCHEDULE_ENTRY_ID, NAME, LOADING_APPLICATION_ID,"
 					+ " ROUTINGSPEC_ID, START_TIME, TIMEZONE, RUN_INTERVAL, ENABLED, LAST_MODIFIED)"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiSiteDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiSiteDAO.java
@@ -367,11 +367,7 @@ public class ApiSiteDAO extends ApiDaoBase
 				+ "REGION, TIMEZONE, COUNTRY, ELEVATION, ELEVUNITABBR, "
 				+ "DESCRIPTION, ACTIVE_FLAG, LOCATION_TYPE, MODIFY_TIME, PUBLIC_NAME) "
 				+ "values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
-				
-		Connection conn = null;
-		try
-		{
-		
+
 		doModifyV(q, site.getSiteId(),
 					site.getLatitude(),
 					site.getLongitude(),
@@ -385,13 +381,9 @@ public class ApiSiteDAO extends ApiDaoBase
 					site.getDescription(),
 					sqlBoolean(site.isActive()),
 					site.getLocationType(),
-					dbi.sqlDate(site.getLastModified()),
+					dbi.sqlDateV(site.getLastModified()),
 					site.getPublicName());
-		}
-		finally
-		{
-			conn.close();
-		}
+
 		updateAllSiteNames(site, new ApiSite());
 		
 		updateSiteProps(site, new ApiSite());

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiSiteDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiSiteDAO.java
@@ -359,7 +359,7 @@ public class ApiSiteDAO extends ApiDaoBase
 	}
 
 	protected void insert(ApiSite site)
-		throws DbException, SQLException
+		throws DbException
 	{
 		site.setSiteId(getKey(DbInterface.Sequences.SITE));
 		

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiSiteDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiSiteDAO.java
@@ -231,7 +231,7 @@ public class ApiSiteDAO extends ApiDaoBase
 				}
 				//this.closePrepConn();
 				// Allocate new ID
-				site.setSiteId(getKey("SITE"));
+				site.setSiteId(getKey(DbInterface.Sequences.SITE));
 				insert(site);
 			}
 			else
@@ -361,7 +361,7 @@ public class ApiSiteDAO extends ApiDaoBase
 	protected void insert(ApiSite site)
 		throws DbException, SQLException
 	{
-		site.setSiteId(getKey("Site"));
+		site.setSiteId(getKey(DbInterface.Sequences.SITE));
 		
 		String q = "insert into SITE(ID, LATITUDE, LONGITUDE, NEARESTCITY, STATE, "
 				+ "REGION, TIMEZONE, COUNTRY, ELEVATION, ELEVUNITABBR, "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiTsDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiTsDAO.java
@@ -554,7 +554,7 @@ public class ApiTsDAO
 	{
 		String q = "insert into TSDB_GROUP(GROUP_ID, GROUP_NAME, GROUP_TYPE, GROUP_DESCRIPTION)"
 			+ " values(?,?,?,?)";
-		grp.setGroupId(getKey("TSDB_GROUP"));
+		grp.setGroupId(getKey(DbInterface.Sequences.TSDB_GROUP));
 		doModifyV(q, grp.getGroupId(), grp.getGroupName(), grp.getGroupType(), grp.getDescription());
 	}
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiUnitDAO.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/ApiUnitDAO.java
@@ -293,7 +293,7 @@ public class ApiUnitDAO
 		else // write new converter
 		{
 			q = "insert into UNITCONVERTER values(?,?,?,?,?,?,?,?,?,?)";
-			doModifyV(q, getKey("UNITCONVERTER"), euc.getFromAbbr(),
+			doModifyV(q, getKey(DbInterface.Sequences.UNITCONVERTER), euc.getFromAbbr(),
 				euc.getToAbbr(), euc.getAlgorithm(), euc.getA(), 
 				euc.getB(), euc.getC(), euc.getD(), euc.getE(), euc.getF());
 		}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/hydrojson/DbInterface.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/hydrojson/DbInterface.java
@@ -15,7 +15,6 @@
 
 package org.opendcs.odcsapi.hydrojson;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import java.sql.Connection;
@@ -293,7 +292,11 @@ public class DbInterface
 		return tokenManager;
 	}
 
-	public enum Sequences {
+	/*
+	*   List of sequences in the database.  If the code needs to reference a sequence or access one, it is done here.
+	 */
+	public enum Sequences
+	{
 		SITE("SITE"),
 		DATATYPE("DATATYPE"),
 		CP_ALGORITHM("CP_ALGORITHM"),
@@ -322,9 +325,8 @@ public class DbInterface
 		String getNextVal(boolean isOracle)
 		{
 			String sequenceName = name + sequenceSuffix;
-			String q = isOracle ? ("SELECT " + sequenceName + ".nextval from dual")
+			return isOracle ? ("SELECT " + sequenceName + ".nextval from dual")
 					: ("SELECT nextval('" + sequenceName + "')"); // postgresql syntax
-			return q;
 		}
 	}
 }

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/hydrojson/DbInterface.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/hydrojson/DbInterface.java
@@ -110,7 +110,8 @@ public class DbInterface
 	}
 	
 	public boolean isUserValid(String username, String password)
-			throws DbException, SQLException {
+			throws DbException, SQLException
+	{
 		if (isOracle)
 			throw new DbException(module, null, "User validation not implemented for Oracle.");
 		
@@ -317,9 +318,9 @@ public class DbInterface
 		TSDB_GROUP("TSDB_GROUP");
 		private final String name;
 
-		Sequences(String name) {
+		Sequences(String name)
+		{
 			this.name = name;
-
 		}
 
 		String getNextVal(boolean isOracle)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/hydrojson/DbInterface.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/hydrojson/DbInterface.java
@@ -15,8 +15,11 @@
 
 package org.opendcs.odcsapi.hydrojson;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
@@ -98,48 +101,7 @@ public class DbInterface
 			ex.printStackTrace(System.err);
 			throw new DbException(module, ex, msg);
 		}
-		
-// This doesn't work. isHdb and isCwms are not set yet. They default to false.
-// Also I don't want to have to make a tsdb class, so eventually just get rid of this.
-//		String tsdbClass = 
-//				isHdb ? "decodes.hdb.HdbTimeSeriesDb" :
-//				isCwms ? "decodes.cwms.CwmsTimeSeriesDb" : 
-//				"opendcs.opentsdb.OpenTsdb";
-//		Logger.getLogger(ApiConstants.loggerName).info("tsdbClass=" + tsdbClass);
-//		if (!isTypeDetermined)
-//		{
-//			Logger.getLogger(ApiConstants.loggerName).info(module + " determining database type");
-//			isTypeDetermined = true;
-//
-//			try (ApiDaoBase adb = new ApiDaoBase(this, "DbInterface"))
-//			{
-//				// hdb_damtype table only exists in HDB.
-//				ResultSet rs = adb.doQuery("select * from hdb_damtype");
-//				isHdb = true;
-//				try { rs.close(); } catch(Exception ex) {}
-//			}
-//			catch (Exception ex)
-//			{
-//				isHdb = false;
-//			}
-//			
-//			if (!isHdb)
-//			{
-//				try (ApiDaoBase adb = new ApiDaoBase(this, "DbInterface"))
-//				{
-//					String q = "select distinct parameter_id from cwms_v_parameter";
-//					ResultSet rs = adb.doQuery(q);
-//					isCwms = true;
-//					try { rs.close(); } catch(Exception ex) {}
-//				}
-//				catch (Exception ex)
-//				{
-//					isCwms = false;
-//				}
-//			}
-//			
-//			isOpenTsdb = tsdbClass == "opendcs.opentsdb.OpenTsdb";
-//		}
+
 		if (staleClientChecker == null)
 		{
 			staleClientChecker = new StaleClientChecker();
@@ -200,7 +162,15 @@ Logger.getLogger(ApiConstants.loggerName).warning("isUserValid - Authentication 
 		finally
 		{
 			if (userCon != null)
-				try { userCon.close(); } catch(Exception ex) {}
+				try
+				{
+					userCon.close();
+				}
+				catch (Exception ex)
+				{
+					Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,
+							"There was an Issue closing connection: {0}", ex.getMessage());
+				}
 		}
 	}
 
@@ -233,45 +203,51 @@ Logger.getLogger(ApiConstants.loggerName).warning("isUserValid - Authentication 
 	}
 
 	public Long getKey(String tableName)
-		throws DbException
+			throws DbException, SQLException
 	{
 		String seqname;
 		if (tableName.equalsIgnoreCase("EquipmentModel"))
 			seqname = "EquipmentIdSeq";
 		else
 			seqname = tableName + sequenceSuffix;
-		
-		String q = isOracle ? ("SELECT " + seqname + ".nextval from dual")
-			: ("SELECT nextval('" + seqname + "')"); // postgresql syntax
 
-		try (Statement stmt = connection.createStatement();
-			ResultSet rs = stmt.executeQuery(q))
+		if (Boolean.TRUE.equals(doesSequenceExist(seqname)))
 		{
-			if (rs == null || !rs.next())
+			String q = isOracle ? ("SELECT " + seqname + ".nextval from dual")
+					: ("SELECT nextval('" + seqname + "')"); // postgresql syntax
+
+			try (Statement stmt = connection.createStatement();
+				 ResultSet rs = stmt.executeQuery(q))
 			{
-				String err = "Cannot read sequence value from '" + seqname 
-					+ "': " + (rs == null ? "Null Return" : "Empty Return");
-				throw new DbException(module, null, err);
+				if (rs == null || !rs.next())
+				{
+					String err = "Cannot read sequence value from '" + seqname
+							+ "': " + (rs == null ? "Null Return" : "Empty Return");
+					throw new DbException(module, null, err);
+				}
+
+				long lv = rs.getLong(1);
+				return (rs.wasNull() ? null : (Long) lv);
 			}
-	
-			long lv =  rs.getLong(1);
-			return (rs.wasNull() ? null : (Long)lv);
+			catch (SQLException ex)
+			{
+				String msg = "SQL Error executing '" + q + "': " + ex;
+				throw new DbException(module, ex, msg);
+			}
 		}
-		catch(SQLException ex)
-		{
-			String msg = "SQL Error executing '" + q + "': " + ex;
-			throw new DbException(module, ex, msg);
-		}
+		Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,
+				"Sequence {0} does not exist, but a call was made to access it.", seqname);
+		//Sequence does not exist.  Returning null;
+		return null;
 	}
-	
+
 	public void resetKey(String tableName)
-		throws DbException
+			throws DbException, SQLException
 	{
 		String seqname = tableName + sequenceSuffix;
-		
-		if (isCwms)
-			; // Do nothing -- never reset cwms sequences.
-		else if (isOracle)
+
+		//NOTE - if isCwms, Do nothing -- never reset cwms sequences.
+		if (isOracle)
 		{
 			// Primitive Oracle SQL requires 4 steps:
 			// 1. Get current sequence value
@@ -279,21 +255,27 @@ Logger.getLogger(ApiConstants.loggerName).warning("isUserValid - Authentication 
 			// 3. Get next sequence value (which causes increment to be applied).
 			// 4. Set increment back to 1.
 			Long curval = getKey(tableName);
-			
-			String q = "alter sequence " + seqname + " increment by -" + (curval-2);
-			try (Statement stmt = connection.createStatement())
+			if (curval != null)
 			{
-				stmt.executeUpdate(q);
-				q = "SELECT " + seqname + ".nextval from dual";
-				ResultSet rs = stmt.executeQuery(q);
-				rs.close();
-				q = "alter sequence " + seqname + " increment by 1 minvalue 0";
-				stmt.executeUpdate(q);
+				String q = "alter sequence " + seqname + " increment by -" + (curval - 2);
+				try (Statement stmt = connection.createStatement()) {
+					stmt.executeUpdate(q);
+					q = "SELECT " + seqname + ".nextval from dual";
+					ResultSet rs = stmt.executeQuery(q);
+					rs.close();
+					q = "alter sequence " + seqname + " increment by 1 minvalue 0";
+					stmt.executeUpdate(q);
+				}
+				catch (SQLException ex)
+				{
+					String msg = "SQL Error executing '" + q + "': " + ex;
+					throw new DbException(module, ex, msg);
+				}
 			}
-			catch(SQLException ex)
+			else
 			{
-				String msg = "SQL Error executing '" + q + "': " + ex;
-				throw new DbException(module, ex, msg);
+				Logger.getLogger(ApiConstants.loggerName).log(Level.SEVERE,
+						"There was an issue resetting sequence {0}.", seqname);
 			}
 		}
 		else // PostgreSQL
@@ -312,6 +294,26 @@ Logger.getLogger(ApiConstants.loggerName).warning("isUserValid - Authentication 
 
 		
 		
+	}
+
+	protected List<String> getAllSequenceNames() throws SQLException
+	{
+		String q = "SELECT LOWER(sequence_name) FROM information_schema.sequences ORDER BY sequence_name;";
+		List<String> sequenceNames = new ArrayList<>();
+		try (Statement stmt = connection.createStatement())
+		{
+			ResultSet rs = stmt.executeQuery(q);
+			while (rs.next())
+			{
+				sequenceNames.add(rs.getString(1));
+			}
+		}
+		return sequenceNames;
+	}
+
+	protected Boolean doesSequenceExist(String sequenceName) throws SQLException
+	{
+		return getAllSequenceNames().contains(sequenceName.toLowerCase());
 	}
 
 	public static void setDatabaseType(String dbType)


### PR DESCRIPTION
## Problem Description
For simplification, getKey and resetKey pass the table/sequence name as a parameter and builds the sequence query based on that variable. We might want to verify that the sequence actually exists to prevent a possible sql injection.
NOTE - Currently, the only use of this is to not ever pass user input into this function. This might be a better solution, as getting all of the sequence names is inefficient.

Fixes #108. 

If user input is passed into this function, it could be problematic for sql injection.

## Solution
Possible solutions:
1)  Check that the sequence name exists before running the query.  (This is the solution I implemented, but I think it's too inefficient).
2) Make sure user input is never passed into this function. (preferred method)
3) Create new functions for each sequence.

## how you tested the change
I ran the code against a valid sequence and it went through successfully.  Then I ran it against a sequence that did not exist and it did not run the query.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate
