### PR TITLE
Give the OpenDcsDataTable class the ability to add cell borders.

### DIFF
--- a/opendcs-web-client/src/main/webapp/resources/css/main.css
+++ b/opendcs-web-client/src/main/webapp/resources/css/main.css
@@ -368,6 +368,12 @@ html .content {
 	background-color: #f0756c !important;
 }
 
+.opendcs-bordered-cells td {
+	border-style: solid;
+	border-width: 1px;
+	border-color: #d6d6d6;
+}
+
 /**** Editable Select ****/
 .select-editable {
      position:relative;

--- a/opendcs-web-client/src/main/webapp/resources/js/datatables/datatables.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/datatables/datatables.js
@@ -26,7 +26,8 @@ class OpenDcsDataTable {
 	  }
     this.domId = domId;
     this.jq = $(`#${domId}`);
-    this.tableProperties = tableProperties != null ? tableProperties : defaultTableProperties;
+    this.tableProperties = tableProperties != undefined && tableProperties != null
+        ? tableProperties : defaultTableProperties;
     this.properties = properties;
     
     this.setInlineOptions(inlineOptions);

--- a/opendcs-web-client/src/main/webapp/resources/js/datatables/datatables.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/datatables/datatables.js
@@ -14,8 +14,11 @@
  */
 
 class OpenDcsDataTable {
-  constructor(domId, properties, inlineOptions, actions, initialize) {
+  constructor(domId, properties, inlineOptions, actions, initialize, tableProperties) {
 	  console.log("In super constructor for OpenDcsDataTable.");
+      var defaultTableProperties = {
+                                      cellBorders: true
+                                  };
 	  //Remove # if the passed id starts with one.
 	  if (domId.startsWith("#"))
 	  {
@@ -23,7 +26,7 @@ class OpenDcsDataTable {
 	  }
     this.domId = domId;
     this.jq = $(`#${domId}`);
-    
+    this.tableProperties = tableProperties != null ? tableProperties : defaultTableProperties;
     this.properties = properties;
     
     this.setInlineOptions(inlineOptions);
@@ -40,6 +43,15 @@ class OpenDcsDataTable {
   
   initDataTable() {
     this.dataTable = this.jq.DataTable(this.properties);
+
+    if (this.tableProperties != null)
+    {
+        if (this.tableProperties.cellBorders)
+        {
+            //Make the cells slightly bordered by adding this class to the table.
+            this.jq.addClass("opendcs-bordered-cells");
+        }
+    }
     this.jq.closest(".dataTables_wrapper").find("[function=addBlankRow]")
     	.on("click", {thisObject: this}, function(e) {
             e.data.thisObject.addBlankRowToDataTable(true);
@@ -658,7 +670,7 @@ class OpenDcsDataTable {
 
 
 class BasicTable extends OpenDcsDataTable {
-  constructor(domId, initialize) {
+  constructor(domId, initialize, tableProperties) {
 	  console.log("In constructor for Child Class Basic Table.");
 	  var defaultProps = {
 		        "searching": false,
@@ -688,12 +700,12 @@ class BasicTable extends OpenDcsDataTable {
           "onclick": null
       }];
 	  super(domId, defaultProps, defaultInlineOptions, 
-			  defaultActions, initialize);
+			  defaultActions, initialize, tableProperties);
   }
 }
 
 class PropertiesTable extends OpenDcsDataTable {
-  constructor(domId, propspecClasses, initialize) {
+  constructor(domId, propspecClasses, initialize, tableProperties) {
 	  console.log("In constructor for Child Class Properties Table.");
 	  var defaultProps = {
 	          "searching": false,
@@ -724,7 +736,8 @@ class PropertiesTable extends OpenDcsDataTable {
           "onclick": null
       }];
 	  super(domId, defaultProps, defaultInlineOptions, 
-			  defaultActions, initialize);
+			  defaultActions, initialize, tableProperties);
+
 	  this.propSpecMeta = {};
 	  if (propspecClasses != null)
 	  {


### PR DESCRIPTION
## Problem Description
Right now, data tables cannot have cell borders.  We need to have the ability to add in cell borders.

## Solution
Give the ability, from an OOP perspective, for datatables to have cell borders.  This will be an optional object that will be passed into the OpenDcsDataTable constructor, where by default the cell borders will be set to true if this optional object is not passed in.

## how you tested the change
Verified the cell borders exist if:
1) The object is passed in with cellBorders = true.
2) The object is not passed in.
Verified the cell borders do not exist if:
1) The object is passed in with cellBorders = false;

## Where the following done:
- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate
