### PR TITLE
Minor Web UI Bugfixes

### DIFF
--- a/opendcs-web-client/src/main/webapp/resources/js/platforms.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/platforms.js
@@ -596,21 +596,23 @@ function openSensorInfoDialog(rowClicked)
             $("#platformSpecificMaxTextbox").val(rowData[7]);
             $("#usgsDdnoTextbox").val(rowData[8]);
 
-            if (platformSensorData != null)
-            {
-                var sensProps = JSON.parse(rowData[5]);
-
-                var actions = [{
-                    "type": "delete",
-                    "onclick": null
-                }];
-                setOpendcsPropertiesTable("platformSensorPropertiesTable", 
-                        openDcsData.propspecs["decodes.db.PlatformSensor"].data, 
-                        sensProps, 
-                        true, 
-                        null, 
-                        actions);
+            //The actual values that are set, not just the propspecs.
+            var sensProps = {};
+            if (platformSensorData != null) {
+                sensProps = JSON.parse(rowData[5]);
             }
+
+            var actions = [{
+                "type": "delete",
+                "onclick": null
+            }];
+            setOpendcsPropertiesTable("platformSensorPropertiesTable",
+                    openDcsData.propspecs["decodes.db.PlatformSensor"].data,
+                    sensProps,
+                    true,
+                    null,
+                    actions);
+
             if (configSensorData != null)
             {
                 if (configSensorData.absoluteMin != null)


### PR DESCRIPTION
## Problem Description

There are several minor bugs and enhancements needing to be addresses in the web UI, they are:

Bugs
- Schedule Entry page does not highlight in the sidebar when open.
- Fixed propspecs code where prop specs were not being displated if there was no platform sensor data available (on the platforms page)
- Fixed bug where platform selections were not appearing properly.

Minor Enhancements
- New rows added to properties table show up as green.
- action dropdowns appear to the left of the menu instead of below.
- action dropdowns will auto scroll into view where applicable (when they open and are off the visible div).
- login button is now properly margin'd below.
