### PR TITLE
Add coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=opendcs_rest_api&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=opendcs_rest_api)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=opendcs_rest_api&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=opendcs_rest_api)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=opendcs_rest_api&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=opendcs_rest_api)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=opendcs_rest_api&metric=coverage)](https://sonarcloud.io/summary/new_code?id=opendcs_rest_api)
 
 # rest_api
 OpenDCS Rest API is web application that provides access to the OpenDCS database using JSON (Java Script Object Notation).


### PR DESCRIPTION
I was looking at code coverage setups and realized there's no badge specific to the current coverage.

NOTE: I will be adding this to the core code after the gradle migration. I believe it's a similar number.