### PR TITLE
Remove configuration usage for PlatformResources integration testing

### DIFF
--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/fixtures/DatabaseSetupExtension.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/fixtures/DatabaseSetupExtension.java
@@ -21,12 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import javax.servlet.http.HttpServletResponse;
 
-import decodes.db.DatabaseException;
-import decodes.db.PlatformStatus;
-import decodes.db.ScheduleEntryStatus;
 import io.restassured.RestAssured;
-import opendcs.dai.PlatformStatusDAI;
-import opendcs.dai.ScheduleEntryDAI;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.PreconditionViolationException;
@@ -61,6 +56,11 @@ public class DatabaseSetupExtension implements BeforeEachCallback
 	public static DbType getCurrentDbType()
 	{
 		return currentDbType;
+	}
+
+	public static Configuration getCurrentConfig()
+	{
+		return currentConfig;
 	}
 
 	public static TomcatServer getCurrentTomcat()
@@ -168,30 +168,6 @@ public class DatabaseSetupExtension implements BeforeEachCallback
 					files[i]);
 		}
 		currentConfig.loadXMLData(filePaths, new SystemExit(), new SystemProperties());
-	}
-
-	public static void storeScheduleEntryStatus(ScheduleEntryStatus status) throws DatabaseException
-	{
-		try (ScheduleEntryDAI dai = currentConfig.getTsdb().makeScheduleEntryDAO())
-		{
-			dai.writeScheduleStatus(status);
-		}
-		catch(Throwable e)
-		{
-			throw new DatabaseException("Unable to store schedule entry status", e);
-		}
-	}
-
-	public static void storePlatformStatus(PlatformStatus status) throws DatabaseException
-	{
-		try (PlatformStatusDAI dai = currentConfig.getTsdb().makePlatformStatusDAO())
-		{
-			dai.writePlatformStatus(status);
-		}
-		catch(Throwable e)
-		{
-			throw new DatabaseException("Unable to store platform status", e);
-		}
 	}
 
 	private void setupClientUser()

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/it/BaseIT.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/it/BaseIT.java
@@ -25,10 +25,18 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import decodes.db.DatabaseException;
+import decodes.db.PlatformStatus;
+import decodes.db.ScheduleEntry;
+import decodes.db.ScheduleEntryStatus;
+import decodes.sql.DbKey;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.filter.session.SessionFilter;
 import io.restassured.path.json.JsonPath;
+import opendcs.dai.PlatformStatusDAI;
+import opendcs.dai.ScheduleEntryDAI;
 import org.apache.catalina.session.StandardSession;
+import org.opendcs.fixtures.configuration.Configuration;
 import org.opendcs.odcsapi.fixtures.DatabaseSetupExtension;
 import org.opendcs.odcsapi.fixtures.DbType;
 import org.opendcs.odcsapi.fixtures.TomcatServer;
@@ -173,5 +181,58 @@ class BaseIT
 		String credentialsJson = Base64.getEncoder()
 				.encodeToString(String.format("%s:%s", adminCreds.getUsername(), adminCreds.getPassword()).getBytes());
 		authHeader = authHeaderPrefix + credentialsJson;
+	}
+
+	public static void storeScheduleEntryStatus(ScheduleEntryStatus status) throws DatabaseException
+	{
+		Configuration currentConfig = DatabaseSetupExtension.getCurrentConfig();
+		try (ScheduleEntryDAI dai = currentConfig.getTsdb().makeScheduleEntryDAO())
+		{
+			dai.writeScheduleStatus(status);
+		}
+		catch (Throwable ex)
+		{
+			throw new DatabaseException("Error storing schedule entry status", ex);
+		}
+	}
+
+	public static void deleteScheduleEntryStatus(DbKey statusId) throws DatabaseException
+	{
+		Configuration currentConfig = DatabaseSetupExtension.getCurrentConfig();
+		try (ScheduleEntryDAI dai = currentConfig.getTsdb().makeScheduleEntryDAO())
+		{
+			ScheduleEntry entry = new ScheduleEntry(statusId);
+			dai.deleteScheduleStatusFor(entry);
+		}
+		catch (Throwable ex)
+		{
+			throw new DatabaseException("Error deleting schedule entry status", ex);
+		}
+	}
+
+	public static void storePlatformStatus(PlatformStatus status) throws DatabaseException
+	{
+		Configuration currentConfig = DatabaseSetupExtension.getCurrentConfig();
+		try (PlatformStatusDAI dai = currentConfig.getTsdb().makePlatformStatusDAO())
+		{
+			dai.writePlatformStatus(status);
+		}
+		catch (Throwable ex)
+		{
+			throw new DatabaseException("Error storing platform status", ex);
+		}
+	}
+
+	public static void deletePlatformStatus(DbKey statusId) throws DatabaseException
+	{
+		Configuration currentConfig = DatabaseSetupExtension.getCurrentConfig();
+		try (PlatformStatusDAI dai = currentConfig.getTsdb().makePlatformStatusDAO())
+		{
+			dai.deletePlatformStatus(statusId);
+		}
+		catch (Throwable ex)
+		{
+			throw new DatabaseException("Error deleting platform status", ex);
+		}
 	}
 }


### PR DESCRIPTION
## Problem Description

The integration testing for PlatformResources relies on storing data via methods added to the OpenDCS Configuration class. These methods should not be in that class, so a refactor is needed.

## Solution

Swaps usage of methods in the Configuration class for DAO calls via the DAO access methods in the Configuration class.

## how you tested the change

Integration tested in the REST API against an OpenTSDB instance.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
