### PR TITLE
Fixed void method usage in ConfigResources

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
@@ -132,7 +132,7 @@ public final class ConfigResources extends OpenDcsResource
 		{
 			PlatformConfig config = new PlatformConfig();
 			config.setId(DbKey.createDbKey(configId));
-			config = dbIo.readConfig(config);
+			dbIo.readConfig(config);
 			return Response.status(HttpServletResponse.SC_OK).entity(map(config)).build();
 		}
 		catch (ValueNotFoundException ex)


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
The return type of the readConfig method used in the ConfigResources controller class is being changed to void in this PR: https://github.com/opendcs/opendcs/pull/901

## Solution

Removed the assignment of the return value of the method.

## how you tested the change

Integration tested in REST API against OpenTSDB and CWMS database instances.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
