### PR TITLE
PresentationResources mapping bugfix

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/OpenDcsDatabaseFactory.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/OpenDcsDatabaseFactory.java
@@ -60,6 +60,7 @@ public final class OpenDcsDatabaseFactory
 			LOGGER.atWarn().setCause(e).log("Temporary solution forcing OpenTSDB");
 			DecodesSettings decodesSettings = new DecodesSettings();
 			decodesSettings.CwmsOfficeId = System.getProperty("DB_OFFICE");
+			decodesSettings.sqlKeyGenerator = System.getProperty("KEYGENERATOR");
 			try(Connection connection = dataSource.getConnection())
 			{
 				DatabaseProvider databaseProvider;

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
@@ -240,9 +240,9 @@ public final class PresentationResources extends OpenDcsResource
 		}
 		group.isProduction = presGrp.isProduction();
 		group.inheritsFrom = presGrp.getInheritsFrom();
-		PresentationGroup apiGroup = new PresentationGroup();
 		if (presGrp.getInheritsFromId() != null)
 		{
+			PresentationGroup apiGroup = new PresentationGroup();
 			apiGroup.groupName = presGrp.getInheritsFrom();
 			apiGroup.setId(DbKey.createDbKey(presGrp.getInheritsFromId()));
 			group.parent = apiGroup;

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
@@ -242,10 +242,10 @@ public final class PresentationResources extends OpenDcsResource
 		group.inheritsFrom = presGrp.getInheritsFrom();
 		if (presGrp.getInheritsFromId() != null)
 		{
-			PresentationGroup apiGroup = new PresentationGroup();
-			apiGroup.groupName = presGrp.getInheritsFrom();
-			apiGroup.setId(DbKey.createDbKey(presGrp.getInheritsFromId()));
-			group.parent = apiGroup;
+			PresentationGroup parentGroup = new PresentationGroup();
+			parentGroup.groupName = presGrp.getInheritsFrom();
+			parentGroup.setId(DbKey.createDbKey(presGrp.getInheritsFromId()));
+			group.parent = parentGroup;
 		}
 		group.dataPresentations = map(dai, presGrp.getElements(), group);
 

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/fixtures/DatabaseSetupExtension.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/fixtures/DatabaseSetupExtension.java
@@ -109,6 +109,7 @@ public class DatabaseSetupExtension implements BeforeEachCallback
 			String initScript = String.format("BEGIN cwms_ccp_vpd.set_ccp_session_ctx(cwms_util.get_office_code('%s'), 2, '%s' ); END;", dbOffice, dbOffice);
 			System.setProperty("DB_CONNECTION_INIT", initScript);
 			DbInterface.decodesProperties.setProperty("CwmsOfficeId", dbOffice);
+			System.setProperty("KEYGENERATOR", "decodes.sql.OracleSequenceKeyGenerator");
 			DbInterface.setDatabaseType("cwms");
 		}
 		else
@@ -117,6 +118,7 @@ public class DatabaseSetupExtension implements BeforeEachCallback
 			System.setProperty("DB_DRIVER_CLASS", "org.postgresql.Driver");
 			System.setProperty("DB_DATASOURCE_CLASS", "org.apache.tomcat.jdbc.pool.DataSourceFactory");
 			System.setProperty("DB_CONNECTION_INIT", "SELECT 1");
+			System.setProperty("KEYGENERATOR", "decodes.sql.SequenceKeyGenerator");
 		}
 		setupClientUser();
 		TomcatServer tomcat = new TomcatServer("build/tomcat", 0, warContext);


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
The mapping of the presentation group parent data created an object even when the parent value was empty.
There is also a key generation error when running against a CWMS database.

## Solution

Refactored mapping to only create object when presentation group parent data is present. Added key sequencer property.

## how you tested the change

Integration tested against OpenTSDB and CWMS database instances.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
