### PR TITLE
Removed custom properties mapping in DataSourceResources, used Toolkit implementations

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
@@ -253,7 +253,10 @@ public class DataSourceResources extends OpenDcsResource
 		ds.setName(ads.getName());
 		ds.dataSourceType = ads.getType();
 		ds.arguments = ads.getProps();
-		ds.setDataSourceArg(props2string(ads.getProps()));
+		if (ads.getProps() != null)
+		{
+			ds.setDataSourceArg(props2string(ads.getProps()));
+		}
 		ds.numUsedBy = ads.getUsedBy();
 		ds.groupMembers = map(ads.getGroupMembers());
 		return ds;

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
@@ -17,7 +17,6 @@ package org.opendcs.odcsapi.res;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.Vector;
 
 import javax.annotation.security.RolesAllowed;
@@ -48,6 +47,10 @@ import org.opendcs.odcsapi.errorhandling.DatabaseItemNotFoundException;
 import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.opendcs.odcsapi.util.ApiConstants;
+
+import static ilex.util.PropertiesUtil.props2string;
+import static ilex.util.PropertiesUtil.string2props;
+
 
 @Path("/")
 public class DataSourceResources extends OpenDcsResource
@@ -96,7 +99,7 @@ public class DataSourceResources extends OpenDcsResource
 			adr.setUsedBy(ds.numUsedBy);
 			if (ds.getArguments() != null)
 			{
-				adr.setArguments(propsToString(ds.getArguments()));
+				adr.setArguments(props2string(ds.getArguments()));
 			}
 			else
 			{
@@ -105,21 +108,6 @@ public class DataSourceResources extends OpenDcsResource
 			ret.add(adr);
 		}
 		return ret;
-	}
-
-	static String propsToString(Properties props)
-	{
-		if (props == null || props.isEmpty())
-		{
-			return null;
-		}
-
-		StringBuilder retVal = new StringBuilder();
-		for (Object key : props.keySet())
-		{
-			retVal.append(key).append("=").append(props.getProperty((String) key)).append(",");
-		}
-		return retVal.substring(0, retVal.length() - 1);
 	}
 
 	@GET
@@ -189,7 +177,7 @@ public class DataSourceResources extends OpenDcsResource
 		}
 		else
 		{
-			ads.setProps(parseProps(ds.getDataSourceArg()));
+			ads.setProps(string2props(ds.getDataSourceArg()));
 		}
 		ads.setGroupMembers(map(ds.groupMembers));
 		ads.setUsedBy(ds.numUsedBy);
@@ -265,7 +253,7 @@ public class DataSourceResources extends OpenDcsResource
 		ds.setName(ads.getName());
 		ds.dataSourceType = ads.getType();
 		ds.arguments = ads.getProps();
-		ds.setDataSourceArg(propsToString(ads.getProps()));
+		ds.setDataSourceArg(props2string(ads.getProps()));
 		ds.numUsedBy = ads.getUsedBy();
 		ds.groupMembers = map(ads.getGroupMembers());
 		return ds;
@@ -330,21 +318,5 @@ public class DataSourceResources extends OpenDcsResource
 		{
 			dbIo.close();
 		}
-	}
-
-	static Properties parseProps(String properties)
-	{
-		if (properties == null || properties.isEmpty())
-		{
-			return new Properties();
-		}
-		Properties props = new Properties();
-		String[] pairs = properties.split(",");
-		for (String pair : pairs)
-		{
-			String[] keyValue = pair.split("=");
-			props.setProperty(keyValue[0], keyValue[1]);
-		}
-		return props;
 	}
 }

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/DataSourceResourcesTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/DataSourceResourcesTest.java
@@ -13,6 +13,8 @@ import org.opendcs.odcsapi.beans.ApiDataSource;
 import org.opendcs.odcsapi.beans.ApiDataSourceGroupMember;
 import org.opendcs.odcsapi.beans.ApiDataSourceRef;
 
+import static ilex.util.PropertiesUtil.props2string;
+import static ilex.util.PropertiesUtil.string2props;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.opendcs.odcsapi.res.DataSourceResources.map;
-import static org.opendcs.odcsapi.res.DataSourceResources.parseProps;
 
 final class DataSourceResourcesTest
 {
@@ -167,11 +168,11 @@ final class DataSourceResourcesTest
 		ApiDataSource apiData = new ApiDataSource();
 		apiData.setProps(props);
 
-		String result = DataSourceResources.propsToString(apiData.getProps());
+		String result = props2string(apiData.getProps());
 
 		assertNotNull(result);
-		String expected = "key=value,key2=value2";
-		String alternativeExpected = "key2=value2,key=value";
+		String expected = "key=value, key2=value2";
+		String alternativeExpected = "key2=value2, key=value";
 		assertThat(result, anyOf(is(expected), is(alternativeExpected)));
 	}
 
@@ -179,13 +180,13 @@ final class DataSourceResourcesTest
 	void testPropertyStringParser()
 	{
 		String propString = "key=value,key2=value2";
-		Properties result = parseProps(propString);
+		Properties result = string2props(propString);
 		assertEquals(2, result.size());
 		assertEquals("value", result.getProperty("key"));
 		assertEquals("value2", result.getProperty("key2"));
 
 		propString = "";
-		result = parseProps(propString);
+		result = string2props(propString);
 		assertEquals(0, result.size());
 	}
 }


### PR DESCRIPTION
## Problem Description

<!-- if you are referencing a specific issue a problem description is not required -->
Custom properties mapping was created when an OpenDCS Toolkit implementation was available.

## Solution
Removed custom mapping, replaced with Toolkit implementation usage.

## how you tested the change

Tested via unit tests.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [x] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
