### PR TITLE
Bugfix: Endpoint Response Messages and Thrown Exceptions

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AlgorithmResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AlgorithmResources.java
@@ -44,6 +44,8 @@ import org.opendcs.odcsapi.beans.ApiAlgoParm;
 import org.opendcs.odcsapi.beans.ApiAlgorithm;
 import org.opendcs.odcsapi.beans.ApiAlgorithmRef;
 import org.opendcs.odcsapi.beans.ApiAlgorithmScript;
+import org.opendcs.odcsapi.errorhandling.DatabaseItemNotFoundException;
+import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.opendcs.odcsapi.util.ApiConstants;
 
@@ -92,8 +94,7 @@ public final class AlgorithmResources extends OpenDcsResource
 	{
 		if(algoId == null)
 		{
-			throw new WebAppException(HttpServletResponse.SC_BAD_REQUEST,
-					"Missing required algorithmid parameter.");
+			throw new MissingParameterException("Missing required algorithmid parameter.");
 		}
 		try(AlgorithmDAI dai = getLegacyTimeseriesDB().makeAlgorithmDAO())
 		{
@@ -104,8 +105,7 @@ public final class AlgorithmResources extends OpenDcsResource
 		}
 		catch(NoSuchObjectException e)
 		{
-			throw new WebAppException(HttpServletResponse.SC_NOT_FOUND,
-					"No Computation Algorithm with id=" + algoId, e);
+			throw new DatabaseItemNotFoundException(String.format("No Computation Algorithm with id: %d", algoId), e);
 		}
 	}
 
@@ -196,8 +196,13 @@ public final class AlgorithmResources extends OpenDcsResource
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
-	public Response deleteAlgorithm(@QueryParam("algorithmid") Long algorithmId) throws TsdbException
+	public Response deleteAlgorithm(@QueryParam("algorithmid") Long algorithmId)
+			throws TsdbException, MissingParameterException
 	{
+		if (algorithmId == null)
+		{
+			throw new MissingParameterException("Missing required algorithmid parameter.");
+		}
 		try(AlgorithmDAI dai = getLegacyTimeseriesDB().makeAlgorithmDAO())
 		{
 			dai.deleteAlgorithm(DbKey.createDbKey(algorithmId));

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -110,12 +110,11 @@ public final class AppResources extends OpenDcsResource
 		}
 		catch (NoSuchObjectException e)
 		{
-			return Response.status(HttpServletResponse.SC_NOT_FOUND)
-					.entity(String.format(NO_APP_FOUND, appId)).build();
+			throw new DatabaseItemNotFoundException(String.format(NO_APP_FOUND, appId), e);
 		}
 		catch (DbIoException ex)
 		{
-			throw new DbException(String.format(NO_APP_FOUND, appId), ex);
+			throw new DbException(String.format("Unable to retrieve requested app with id: %d", appId), ex);
 		}
 	}
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -404,7 +404,7 @@ public final class ComputationResources extends OpenDcsResource
 		{
 			dai.deleteComputation(DbKey.createDbKey(computationId));
 			return Response.status(HttpServletResponse.SC_NO_CONTENT)
-					.entity("Computation with ID " + computationId + " deleted").build();
+					.entity(String.format("Computation with ID: %d deleted", computationId)).build();
 		}
 		catch(DbIoException | ConstraintException e)
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
@@ -213,13 +213,8 @@ public class DataSourceResources extends OpenDcsResource
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
-	public Response postDatasource(ApiDataSource datasource) throws DbException, MissingParameterException
+	public Response postDatasource(ApiDataSource datasource) throws DbException
 	{
-		if (datasource == null)
-		{
-			throw new MissingParameterException("Missing required data source object.");
-		}
-
 		DatabaseIO dbIo = getLegacyDatabase();
 		try
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
@@ -179,15 +179,11 @@ public final class NetlistResources extends OpenDcsResource
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
 	public Response  postNetlist(ApiNetList netList)
-			throws DbException, WebAppException
+			throws DbException
 	{
 		DatabaseIO dbIo = getLegacyDatabase();
 		try
 		{
-			if (netList == null)
-			{
-				throw new MissingParameterException("Missing required request body.");
-			}
 			NetworkList nlList = map(netList);
 			dbIo.writeNetworkList(nlList);
 			return Response.status(HttpServletResponse.SC_CREATED).entity(map(nlList)).build();

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
@@ -36,6 +36,7 @@ import decodes.tsdb.TimeSeriesDb;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.odcsapi.beans.DecodeRequest;
 import org.opendcs.odcsapi.dao.DbException;
+import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.opendcs.odcsapi.opendcs_dep.PropSpecHelper;
 import org.opendcs.odcsapi.opendcs_dep.TestDecoder;
@@ -100,7 +101,7 @@ public final class OdcsapiResource extends OpenDcsResource
 	{
 		if (className == null)
 		{
-			throw new WebAppException(HttpServletResponse.SC_BAD_REQUEST, "Missing required class argument.");
+			throw new MissingParameterException("Missing required class argument.");
 		}
 
 		return Response.status(HttpServletResponse.SC_OK).entity(PropSpecHelper.getPropSpecs(className)).build();
@@ -116,7 +117,7 @@ public final class OdcsapiResource extends OpenDcsResource
 	{
 		if (scriptName == null)
 		{
-			throw new WebAppException(HttpServletResponse.SC_BAD_REQUEST, "Missing required script argument.");
+			throw new MissingParameterException("Missing required script argument.");
 		}
 		OpenDcsDatabase db = createDb();
 

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
@@ -279,6 +279,10 @@ public final class ReflistResources extends OpenDcsResource
 	public Response getSeason(@QueryParam("abbr") String abbr)
 			throws DbException, WebAppException
 	{
+		if (abbr == null)
+		{
+			throw new MissingParameterException("Missing required 'abbr' argument.");
+		}
 		try (EnumDAI dai  = getLegacyTimeseriesDB().makeEnumDAO())
 		{
 			DbKey seasonId = dai.getEnumId(SEASON_ENUM);

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RoutingResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RoutingResources.java
@@ -305,7 +305,7 @@ public final class RoutingResources extends OpenDcsResource
 			spec.setId(DbKey.createDbKey(routingId));
 			dbIo.deleteRoutingSpec(spec);
 			return Response.status(HttpServletResponse.SC_NO_CONTENT)
-					.entity("RoutingSpec with ID " + routingId + " deleted").build();
+					.entity(String.format("RoutingSpec with ID: %d deleted", routingId)).build();
 		}
 		catch(DatabaseException e)
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
@@ -48,7 +48,8 @@ import opendcs.dai.SiteDAI;
 import org.opendcs.odcsapi.beans.ApiSite;
 import org.opendcs.odcsapi.beans.ApiSiteRef;
 import org.opendcs.odcsapi.dao.DbException;
-import org.opendcs.odcsapi.errorhandling.ErrorCodes;
+import org.opendcs.odcsapi.errorhandling.DatabaseItemNotFoundException;
+import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.opendcs.odcsapi.util.ApiConstants;
 
@@ -109,8 +110,7 @@ public final class SiteResources extends OpenDcsResource
 	{
 		if (siteId == null)
 		{
-			throw new WebAppException(ErrorCodes.MISSING_ID,
-					"Missing required siteid parameter.");
+			throw new MissingParameterException("Missing required siteid parameter.");
 		}
 
 		try (SiteDAI dai = getLegacyTimeseriesDB().makeSiteDAO();
@@ -125,8 +125,7 @@ public final class SiteResources extends OpenDcsResource
 		}
 		catch (NoSuchObjectException e)
 		{
-			return Response.status(HttpServletResponse.SC_NOT_FOUND)
-					.entity("Requested site with matching ID not found").build();
+			throw new DatabaseItemNotFoundException(String.format("Requested site with matching ID: %d not found", siteId), e);
 		}
 		catch(DbIoException e)
 		{
@@ -188,7 +187,7 @@ public final class SiteResources extends OpenDcsResource
 		{
 			if (site == null)
 			{
-				throw new WebAppException(ErrorCodes.MISSING_ID, "Missing required site parameter.");
+				throw new MissingParameterException("Missing required site parameter.");
 			}
 			Site dbSite = map(site);
 			dai.writeSite(dbSite);
@@ -252,8 +251,7 @@ public final class SiteResources extends OpenDcsResource
 		{
 			if (siteId == null)
 			{
-				throw new WebAppException(ErrorCodes.MISSING_ID,
-						"Missing required siteid parameter.");
+				throw new MissingParameterException("Missing required siteid parameter.");
 			}
 			dai.deleteSite(DbKey.createDbKey(siteId));
 			return Response.status(HttpServletResponse.SC_NO_CONTENT)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
@@ -167,7 +167,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 		}
 		catch (NoSuchObjectException e)
 		{
-			throw new DatabaseItemNotFoundException(String.format("Time series with key: %dnot found", tsKey));
+			throw new DatabaseItemNotFoundException(String.format("Time series with key: %d not found", tsKey), e);
 		}
 		catch (DbIoException ex)
 		{
@@ -545,6 +545,10 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
 	public Response getTsGroup(@QueryParam("groupid") Long groupId) throws DbException, WebAppException
 	{
+		if (groupId == null)
+		{
+			throw new MissingParameterException("Missing required groupid parameter.");
+		}
 		try (TsGroupDAI dai = getLegacyTimeseriesDB().makeTsGroupDAO())
 		{
 			TsGroup group = dai.getTsGroupById(DbKey.createDbKey(groupId));


### PR DESCRIPTION
## Problem Description

Some legacy usages of `WebAppException` were still present instead of the more accurate inheritor classes. Some endpoints were also missing the appropriate checks for missing input parameters.

## Solution

Replaces generic `WebAppException` usages with appropriate `DatabaseItemNotFoundException` and `MissingParameterExeption`.
Also adds `MissingParameterException` to some endpoints that were missing them.

## how you tested the change

Integration tested locally against OpenTSDB and CWMS database instances.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
