### PR TITLE
fix sonar usage so that it can be run from forked repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,16 +41,22 @@ jobs:
       - name: Integration Tests OpenTSDB
         if: always()
         run: ./gradlew integrationTestOpenTSDB --stacktrace --info
-      - name: Analyze
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar
       - name: Upload WAR files
         uses: actions/upload-artifact@v4.6.2
         with:
           name: warfile
           path: ./**/build/libs/*.war
           retention-days: 1
+          if-no-files-found: error
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: test-report
+          path: ./**/build/reports/tests/**
+          if-no-files-found: error
+      - name: Upload Coverage Reports
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: coverage-report
+          path: ./**/build/reports/jacoco/
           if-no-files-found: error

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,53 @@
+name: SonarCloud Scan
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    type: [completed]
+
+jobs:
+  Sonar:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4.3.0
+      - name: Checkout PR
+        uses: actions/checkout@v4.2.1
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Download Coverage
+        uses: actions/download-artifact@v4.1.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./
+          merge-multiple: true
+      - name: Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          ./gradlew sonar --info -Dorg.gradle.jvmargs=-Xmx4096M \
+             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
+             -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }} \
+             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }} \
+             -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}


### PR DESCRIPTION
## Problem Description

Running sonar analysis from a forked repository with a user who does not have write permissions fails authentication to the SonarCloud service.

## Solution

Add a github action hook that triggers as the GitHub account to run based on successful build+test execution so that the correct repo permissions are used.

## how you tested the change

Will be testing by getting @zack-rma to PR into this change.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [X] Were relevant config element (e.g. XML data) updated as appropriate

