### PR TITLE
fix incorrect context used for DataSource attribute

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/AuthorizationCheck.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/AuthorizationCheck.java
@@ -44,7 +44,7 @@ public abstract class AuthorizationCheck
 	public abstract SecurityContext authorize(ContainerRequestContext requestContext,
 			HttpServletRequest httpServletRequest, ServletContext servletContext);
 
-	public abstract boolean supports(String type, ContainerRequestContext requestContext, HttpServletRequest servletRequest);
+	public abstract boolean supports(String type, ContainerRequestContext requestContext, ServletContext servletContext);
 
 
 	protected final ApiAuthorizationDAI getAuthDao(ServletContext servletContext)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/SecurityFilter.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/SecurityFilter.java
@@ -160,7 +160,7 @@ public final class SecurityFilter implements ContainerRequestFilter
 		{
 			for(AuthorizationCheck authType : serviceLoader)
 			{
-				if(authType.supports(type, requestContext, httpServletRequest))
+				if(authType.supports(type, requestContext, servletContext))
 				{
 					return authType;
 				}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/basicauth/BasicAuthCheck.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/basicauth/BasicAuthCheck.java
@@ -61,7 +61,7 @@ public final class BasicAuthCheck extends AuthorizationCheck
 	}
 
 	@Override
-	public boolean supports(String type, ContainerRequestContext ignored, HttpServletRequest servletContext)
+	public boolean supports(String type, ContainerRequestContext ignored, ServletContext servletContext)
 	{
 		DataSource dataSource = (DataSource) servletContext.getAttribute(DATA_SOURCE_ATTRIBUTE_KEY);
 		OpenDcsDatabase db = OpenDcsDatabaseFactory.createDb(dataSource);

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/cwms/ServletSsoAuthCheck.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/cwms/ServletSsoAuthCheck.java
@@ -62,7 +62,7 @@ public final class ServletSsoAuthCheck extends AuthorizationCheck
 	}
 
 	@Override
-	public boolean supports(String type, ContainerRequestContext requestContext, HttpServletRequest ignored)
+	public boolean supports(String type, ContainerRequestContext requestContext, ServletContext ignored)
 	{
 		return "sso".equals(type) && hasSessionCookie(requestContext);
 	}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/openid/OidcAuthCheck.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/openid/OidcAuthCheck.java
@@ -122,7 +122,7 @@ public final class OidcAuthCheck extends AuthorizationCheck
 	}
 
 	@Override
-	public boolean supports(String type, ContainerRequestContext requestContext, HttpServletRequest ignored)
+	public boolean supports(String type, ContainerRequestContext requestContext, ServletContext ignored)
 	{
 		String authorizationHeader = requestContext.getHeaderString(AUTHORIZATION_HEADER);
 		return keySource != null && "openid".equals(type) && authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX);


### PR DESCRIPTION
## Problem Description

Integration tests are failing locally due to incorrect data source context.

## Solution

Use ServletContext, not Request context

## how you tested the change

Tested integration tests locally

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

