### PR TITLE
remove the tarball bundle as we are no longer deploying embedded jetty

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,6 @@ jobs:
         uses: gradle/gradle-build-action@v3.5.0
       - name: Build
         run: ./gradlew build
-      - name: Bundle tarballs
-        run: ./gradlew bundle
       - name: Attach OpenDCS REST API WAR file
         run: |
           gh release upload ${{ github.event.release.tag_name }} opendcs-rest-api/build/libs/opendcs-rest-api-${{ github.event.release.tag_name }}.war --repo ${{ github.repository }}


### PR DESCRIPTION
## Problem Description

Publish is currently breaking due to gradle bundle task that was previously removed.

## Solution

Remove the github action step

## how you tested the change

Will test in next release

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [X] Were relevant config element (e.g. XML data) updated as appropriate

