### PR TITLE
update PropSpecHelper to use new constructor from toolkit refactors

### DIFF
--- a/opendcs-integration-test/build.gradle
+++ b/opendcs-integration-test/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation(libs.opendcs.api)
     implementation(libs.opendcs.integrationtesting.fixtures)
     runtimeClasspath(libs.slf4j.jdk14)
+    runtimeClasspath(libs.jackson)             // for swagger compatibility
+    runtimeClasspath(libs.jackson.annotations) // for swagger compatibility
 
 
     testImplementation(project(":opendcs-rest-api"))
@@ -37,8 +39,6 @@ dependencies {
     testImplementation(libs.hamcrest)
     testImplementation(libs.nimbus)
     testImplementation(libs.jwt)
-    testRuntimeOnly(libs.jackson)             // for swagger compatibility
-    testRuntimeOnly(libs.jackson.annotations) // for swagger compatibility
     testRuntimeOnly(libs.byte.buddy)
     testRuntimeOnly(libs.junit.api)
     testRuntimeOnly(libs.junit.engine)

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelper.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelper.java
@@ -15,8 +15,19 @@
 
 package org.opendcs.odcsapi.opendcs_dep;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import javax.servlet.http.HttpServletResponse;
 
+import decodes.consumer.StringBufferConsumer;
+import decodes.cwms.rating.CwmsRatingSingleIndep;
+import decodes.datasource.FtpDataSource;
+import decodes.datasource.WebDirectoryDataSource;
+import decodes.db.ConfigSensor;
+import decodes.db.DataSource;
+import decodes.db.Database;
+import decodes.dbeditor.RoutingSpecEditPanel;
+import decodes.tsdb.algo.PythonAlgorithm;
 import decodes.util.PropertiesOwner;
 import decodes.util.PropertySpec;
 import org.opendcs.odcsapi.beans.ApiPropSpec;
@@ -24,31 +35,166 @@ import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PropSpecHelper
+public final class PropSpecHelper
 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(PropSpecHelper.class);
-	public static ApiPropSpec[] getPropSpecs(String className)
-		throws WebAppException
+
+	public enum ClassName
 	{
-		PropertySpec[] ps = getDecodesPropSpecs(className);
+		AREA_RATING_COMP_RESOLVER("decodes.comp.AreaRatingCompResolver"),
+		RDB_RATING_COMP_RESOLVER("decodes.comp.RdbRatingCompResolver"),
+		STATION_EXCLUDE_COMP_RESOLVER("decodes.comp.StationExcludeCompResolver"),
+		TAB_RATING_COMP_RESOLVER("decodes.comp.TabRatingCompResolver"),
+		DIRECTORY_CONSUMER("decodes.consumer.DirectoryConsumer"),
+		FILE_APPEND_CONSUMER("decodes.consumer.FileAppendConsumer"),
+		FILE_CONSUMER("decodes.consumer.FileConsumer"),
+		PIPE_CONSUMER("decodes.consumer.PipeConsumer"),
+		STRING_BUFFER_CONSUMER("decodes.consumer.StringBufferConsumer"),
+		TCP_CLIENT_CONSUMER("decodes.consumer.TcpClientConsumer"),
+		ALBERTA_LOADER_FORMATTER("decodes.consumer.AlbertaLoaderFormatter"),
+		CSV_FORMATTER("covesw.azul.consumer.CsvFormatter"),
+		EMIT_ASCII_FORMATTER("decodes.consumer.EmitAsciiFormatter"),
+		EMIT_ORACLE_FORMATTER("decodes.consumer.EmitOracleFormatter"),
+		HEADER_FORMATTER("decodes.consumer.HeaderFormatter"),
+		HTML_FORMATTER("decodes.consumer.HtmlFormatter"),
+		HUMAN_READABLE_FORMATTER("decodes.consumer.HumanReadableFormatter"),
+		HYDRO_JSON_FORMATTER("decodes.consumer.HydroJSONFormatter"),
+		KHYDSTRA_FORMATTER("decodes.consumer.KHydstraFormatter"),
+		KISTERS_FORMATTER("decodes.consumer.KistersFormatter"),
+		NULL_FORMATTER("decodes.consumer.NullFormatter"),
+		RAW_FORMATTER("decodes.consumer.RawFormatter"),
+		SHEF_FORMATTER("decodes.consumer.ShefFormatter"),
+		SHEFIT_FORMATTER("decodes.consumer.ShefitFormatter"),
+		TRANSMIT_MONITOR_FORMATTER("decodes.consumer.TransmitMonitorFormatter"),
+		TS_IMPORT_FORMATTER("decodes.consumer.TsImportFormatter"),
+		CWMS_CONSUMER("decodes.cwms.CwmsConsumer"),
+		DIRECTORY_DATA_SOURCE("decodes.datasource.DirectoryDataSource"),
+		FTP_DATA_SOURCE("decodes.datasource.FtpDataSource"),
+		HOT_BACKUP_GROUP("decodes.datasource.HotBackupGroup"),
+		LRGS_DATA_SOURCE("decodes.datasource.LrgsDataSource"),
+		ROUND_ROBIN_GROUP("decodes.datasource.RoundRobinGroup"),
+		SCP_DATA_SOURCE("decodes.datasource.ScpDataSource"),
+		SOCKET_STREAM_DATA_SOURCE("decodes.datasource.SocketStreamDataSource"),
+		USGS_WEB_DATA_SOURCE("decodes.datasource.UsgsWebDataSource"),
+		WEB_ABSTRACT_DATA_SOURCE("decodes.datasource.WebAbstractDataSource"),
+		WEB_DATA_SOURCE("decodes.datasource.WebDataSource"),
+		WEB_DIRECTORY_DATA_SOURCE("decodes.datasource.WebDirectoryDataSource"),
+		POLLING_DATA_SOURCE("decodes.polling.PollingDataSource"),
+		PLATFORM("decodes.db.Platform"),
+		PLATFORM_SENSOR("decodes.db.PlatformSensor"),
+		CONFIG_SENSOR("decodes.db.ConfigSensor"),
+		ROUTING_SCHEDULER("decodes.routing.RoutingScheduler"),
+		COMP_APP_INFO("decodes.tsdb.CompAppInfo"),
+		HDB_RATING("decodes.tsdb.algo.HdbRating"),
+		RUNNING_AVERAGE_ALGORITHM("decodes.tsdb.algo.RunningAverageAlgorithm"),
+		AVERAGE_ALGORITHM("decodes.tsdb.algo.AverageAlgorithm"),
+		BIG_ADDER("decodes.tsdb.algo.BigAdder"),
+		MULTIPLICATION("decodes.tsdb.algo.Multiplication"),
+		SUM_OVER_TIME_ALGORITHM("decodes.tsdb.algo.SumOverTimeAlgorithm"),
+		EXPRESSION_PARSER_ALGORITHM("decodes.tsdb.algo.ExpressionParserAlgorithm"),
+		FILL_FORWARD("decodes.tsdb.algo.FillForward"),
+		HDB_RESERVOIR_MASS_BALANCE("decodes.tsdb.algo.HdbReservoirMassBalance"),
+		ADD_TO_PREVIOUS("decodes.tsdb.algo.AddToPrevious"),
+		STAT("decodes.tsdb.algo.Stat"),
+		HDB_EVAPORATION("decodes.tsdb.algo.HdbEvaporation"),
+		ESTIMATED_INFLOW("decodes.tsdb.algo.EstimatedInflow"),
+		GROUP_ADDER("decodes.tsdb.algo.GroupAdder"),
+		RESERVOIR_FULL("decodes.tsdb.algo.ReservoirFull"),
+		SCALER_ADDER("decodes.tsdb.algo.ScalerAdder"),
+		HDB_ACAPS_RATING("decodes.tsdb.algo.HdbACAPSRating"),
+		CHOOSE_ONE("decodes.tsdb.algo.ChooseOne"),
+		BRIDGE_CLEARANCE("decodes.tsdb.algo.BridgeClearance"),
+		USGS_EQUATION("decodes.tsdb.algo.UsgsEquation"),
+		INCREMENTAL_PRECIP("decodes.tsdb.algo.IncrementalPrecip"),
+		FLOW_RES_IN("decodes.tsdb.algo.FlowResIn"),
+		COPY_ALGORITHM("decodes.tsdb.algo.CopyAlgorithm"),
+		DIS_AGGREGATE("decodes.tsdb.algo.DisAggregate"),
+		WEIGHTED_WATER_TEMPERATURE("decodes.tsdb.algo.WeightedWaterTemperature"),
+		PYTHON_ALGORITHM("decodes.tsdb.algo.PythonAlgorithm"),
+		RESAMPLE("decodes.tsdb.algo.Resample"),
+		SHOW_ALGO_PROPS("decodes.tsdb.algo.ShowAlgoProps"),
+		PERIOD_TO_DATE("decodes.tsdb.algo.PeriodToDate"),
+		COPY_NO_OVERWRITE("decodes.tsdb.algo.CopyNoOverwrite"),
+		SUB_SAMPLE("decodes.tsdb.algo.SubSample"),
+		CENTRAL_RUNNING_AVERAGE_ALGORITHM("decodes.tsdb.algo.CentralRunningAverageAlgorithm"),
+		TAB_RATING("decodes.tsdb.algo.TabRating"),
+		RDB_RATING("decodes.tsdb.algo.RdbRating"),
+		DIVISION("decodes.tsdb.algo.Division"),
+		VIRTUAL_GAGE("decodes.tsdb.algo.VirtualGage"),
+		ALARM_SCREENING_ALGORITHM("decodes.tsdb.alarm.AlarmScreeningAlgorithm"),
+		INFLOW_ADVANCED_ALG("decodes.hdb.algo.InflowAdvancedAlg"),
+		EQUATION_SOLVER_ALG("decodes.hdb.algo.EquationSolverAlg"),
+		EST_GLDA_INFLOW("decodes.hdb.algo.EstGLDAInflow"),
+		BEGIN_OF_PERIOD_ALG("decodes.hdb.algo.BeginofPeriodAlg"),
+		DYNAMIC_AGGREGATES_ALG("decodes.hdb.algo.DynamicAggregatesAlg"),
+		HDB_SHIFT_RATING("decodes.hdb.algo.HdbShiftRating"),
+		HDB_LOOKUP_TIME_SHIFT_RATING("decodes.hdb.algo.HdbLookupTimeShiftRating"),
+		SIDE_INFLOW_ALG("decodes.hdb.algo.SideInflowAlg"),
+		VOLUME_TO_FLOW_ALG("decodes.hdb.algo.VolumeToFlowAlg"),
+		NVRN_UNREG("decodes.hdb.algo.NVRNUnreg"),
+		POWER_TO_ENERGY_ALG("decodes.hdb.algo.PowerToEnergyAlg"),
+		GLDA_UNREG("decodes.hdb.algo.GLDAUnreg"),
+		CALL_PROC_ALG("decodes.hdb.algo.CallProcAlg"),
+		END_OF_PERIOD_ALG("decodes.hdb.algo.EndofPeriodAlg"),
+		GLDA_EVAP("decodes.hdb.algo.GLDAEvap"),
+		BMDC_UNREG("decodes.hdb.algo.BMDCUnreg"),
+		CRRC_UNREG("decodes.hdb.algo.CRRCUnreg"),
+		PARSHALL_FLUME("decodes.hdb.algo.ParshallFlume"),
+		FLOW_TO_VOLUME_ALG("decodes.hdb.algo.FlowToVolumeAlg"),
+		SIMPLE_DISAGG_ALG("decodes.hdb.algo.SimpleDisaggAlg"),
+		EOP_INTERP_ALG("decodes.hdb.algo.EOPInterpAlg"),
+		TIME_WEIGHTED_AVERAGE_ALG("decodes.hdb.algo.TimeWeightedAverageAlg"),
+		INFLOW_BASIC_ALG("decodes.hdb.algo.InflowBasicAlg"),
+		MPRC_UNREG("decodes.hdb.algo.MPRCUnreg"),
+		GLEN_DELTA_BSMB_ALG("decodes.hdb.algo.GlenDeltaBSMBAlg"),
+		FLGU_UNREG("decodes.hdb.algo.FLGUUnreg"),
+		CWMS_RATING_SINGLE_INDEP("decodes.cwms.rating.CwmsRatingSingleIndep"),
+		CWMS_RATING_MULT_INDEP("decodes.cwms.rating.CwmsRatingMultIndep"),
+		SCREENING_ALGORITHM("decodes.cwms.validation.ScreeningAlgorithm"),
+		DECODES_SETTINGS("decodes.util.DecodesSettings"),
+		LRGS_CONFIG("lrgs.lrgsmain.LrgsConfig"),
+		OPEN_TSDB_SETTINGS("opendcs.opentsdb.OpenTsdbSettings");
+
+		private final String className;
+
+		ClassName(String className)
+		{
+			this.className = className;
+		}
+
+		@Override
+		public String toString()
+		{
+			return className;
+		}
+	}
+
+	private PropSpecHelper()
+	{
+		throw new AssertionError("Utility class");
+	}
+
+
+	public static ApiPropSpec[] getPropSpecs(String className)
+			throws WebAppException
+	{
+		PropertySpec[] ps = gedecodesPropSpecs(className);
 		ApiPropSpec[] ret = new ApiPropSpec[ps.length];
-		for(int i=0; i < ps.length; i++)
+		for(int i = 0; i < ps.length; i++)
 			ret[i] = new ApiPropSpec(ps[i].getName(), ps[i].getType(), ps[i].getDescription());
 		return ret;
 	}
-	
-	
-	public static PropertySpec[] getDecodesPropSpecs(String className)
-		throws WebAppException
+
+
+	private static PropertySpec[] gedecodesPropSpecs(String className) throws WebAppException
 	{
 		//className is user controlled, so it is logged at trace level.
 		LOGGER.trace("PropSpecHelper.getPropSpecs class='{}'", className);
-		if (className.equalsIgnoreCase("decodes.datasource.FtpDataSource"))
+		if (FtpDataSource.class.getName().equalsIgnoreCase(className))
 		{
 			// Can't instantiate the class because it requires Apache FTP libs.
 			// Kludge: copy the specs here.
-			PropertySpec[] ftpDsPropSpecs =
-			{
+			return new PropertySpec[]{
 				new PropertySpec("host", PropertySpec.HOSTNAME,
 					"FTP Data Source: Host name or IP Address of FTP Server"),
 				new PropertySpec("port", PropertySpec.INT,
@@ -65,7 +211,7 @@ public class PropSpecHelper
 					+ " saved locally."),
 				new PropertySpec("filenames", PropertySpec.STRING,
 					"Space-separated list of files to download from server"),
-				new PropertySpec("xferMode", 
+				new PropertySpec("xferMode",
 					PropertySpec.JAVA_ENUM + "decodes.datasource.FtpMode",
 					"FTP Data Source: FTP transfer mode"),
 				new PropertySpec("deleteFromServer", PropertySpec.BOOLEAN,
@@ -78,115 +224,127 @@ public class PropSpecHelper
 					"Use with OneMessageFile=true if the downloaded filename is to be treated as a medium ID"
 					+ " in order to link this data with a platform."),
 				new PropertySpec("ftps", PropertySpec.BOOLEAN, "(default=false) Use Secure FTP."),
-				new PropertySpec("newerThan", PropertySpec.STRING, 
+				new PropertySpec("newerThan", PropertySpec.STRING,
 					"Either a Date/Time in the format [[[CC]YY] DDD] HH:MM[:SS], "
 					+ "or a string of the form 'now - N incr',"
 					+ " where N is an integer and incr is minutes, hours, or days."),
 
 			};
-			return ftpDsPropSpecs;
 		}
-		else if (className.equalsIgnoreCase("decodes.datasource.WebDirectoryDataSource"))
+		else if (WebDirectoryDataSource.class.getName().equalsIgnoreCase(className))
 		{
-			PropertySpec[] webdirPropSpecs =
-				{
-					new PropertySpec("directoryUrl", PropertySpec.STRING,
-						"(required) URL of the directory that lists the file names containing messages"),
-					new PropertySpec("urlFieldDelimiter", PropertySpec.STRING,
-						"(default = underscore) Delimiter for fields within the filenames."),
-					new PropertySpec("urlTimePos", PropertySpec.INT,
-						"(default=3) Position of time within the delimited file name (1=first pos)"),
-					new PropertySpec("urlIdPos", PropertySpec.INT,
-						"(default=5) Position of the transport medium ID within the file name (1=first pos)"),
-					new PropertySpec("urlTimeFormat", PropertySpec.STRING,
-							"(default = HHmmss) SimpleDateFormat format string for time in the filename"),
-					new PropertySpec("urlTimeZone", PropertySpec.STRING,
-							"(default = UTC) Time Zone for the time within the directory and file names")
-				};
-			return webdirPropSpecs;
+			return new PropertySpec[]{
+				new PropertySpec("directoryUrl", PropertySpec.STRING,
+					"(required) URL of the directory that lists the file names containing messages"),
+				new PropertySpec("urlFieldDelimiter", PropertySpec.STRING,
+					"(default = underscore) Delimiter for fields within the filenames."),
+				new PropertySpec("urlTimePos", PropertySpec.INT,
+					"(default=3) Position of time within the delimited file name (1=first pos)"),
+				new PropertySpec("urlIdPos", PropertySpec.INT,
+					"(default=5) Position of the transport medium ID within the file name (1=first pos)"),
+				new PropertySpec("urlTimeFormat", PropertySpec.STRING,
+						"(default = HHmmss) SimpleDateFormat format string for time in the filename"),
+				new PropertySpec("urlTimeZone", PropertySpec.STRING,
+						"(default = UTC) Time Zone for the time within the directory and file names")
+			};
 
 		}
-		else if (className.equalsIgnoreCase("decodes.dbeditor.RoutingSpecEditPanel"))
+		else if (RoutingSpecEditPanel.class.getName().equalsIgnoreCase(className))
 		{
-			PropertySpec rsPropSpecs[] = 
-				{
-					// Properties implemented directly by RoutingSpecThread:
-					new PropertySpec("noLimits", PropertySpec.BOOLEAN,
-						"Do NOT Apply Sensor min/max limits."),
-					new PropertySpec("removeRedundantData", PropertySpec.BOOLEAN,
-						"Remove Redundant DCP Message Data."),
-					new PropertySpec("compConfig", PropertySpec.FILENAME,
-						"Name of in-line computations config file"),
-					new PropertySpec("usgsSummaryFile", PropertySpec.FILENAME,
-						"Optional USGS-Format Summary File"),
-					new PropertySpec("RawArchivePath", PropertySpec.STRING, 
-						"Path to raw archive file. Defining this turns on the raw-archive function. " +
-						"Example: $DCSTOOL_HOME/raw-archive/fts/$DATE(yyMMdd).fts"),
-					new PropertySpec("RawArchiveStartDelim", PropertySpec.STRING, 
-						"String placed before each message in the file"),
-					new PropertySpec("RawArchiveEndDelim", PropertySpec.STRING, 
-						"String placed after each message in the file"),
-					new PropertySpec("RawArchiveMaxAge", PropertySpec.STRING, 
-						"Example: '1 year'. Files older than this are deleted."),
-					new PropertySpec("debugLevel", PropertySpec.INT,
-						"(default=0) Set to 1, 2, 3 for increasing levels of debug information" +
-						" when this routing spec is run."),
-					new PropertySpec("updatePlatformStatus", PropertySpec.BOOLEAN,
-						"(default=true) set to false to NOT update platform status records as messages are processed."),
-					new PropertySpec("purgeOldEvents", PropertySpec.BOOLEAN,
-						"(default=true) Set to false to tell this routing spec to NOT attempt to "
-						+ "purge expired events from the database. Also see DecodesSettings.eventPurgeDays")
-				};
-			return rsPropSpecs;
+			// Properties implemented directly by RoutingSpecThread:
+			return new PropertySpec[]{
+				// Properties implemented directly by RoutingSpecThread:
+				new PropertySpec("noLimits", PropertySpec.BOOLEAN,
+					"Do NOT Apply Sensor min/max limits."),
+				new PropertySpec("removeRedundantData", PropertySpec.BOOLEAN,
+					"Remove Redundant DCP Message Data."),
+				new PropertySpec("compConfig", PropertySpec.FILENAME,
+					"Name of in-line computations config file"),
+				new PropertySpec("usgsSummaryFile", PropertySpec.FILENAME,
+					"Optional USGS-Format Summary File"),
+				new PropertySpec("RawArchivePath", PropertySpec.STRING,
+					"Path to raw archive file. Defining this turns on the raw-archive function. " +
+					"Example: $DCSTOOL_HOME/raw-archive/fts/$DATE(yyMMdd).fts"),
+				new PropertySpec("RawArchiveStartDelim", PropertySpec.STRING,
+					"String placed before each message in the file"),
+				new PropertySpec("RawArchiveEndDelim", PropertySpec.STRING,
+					"String placed after each message in the file"),
+				new PropertySpec("RawArchiveMaxAge", PropertySpec.STRING,
+					"Example: '1 year'. Files older than this are deleted."),
+				new PropertySpec("debugLevel", PropertySpec.INT,
+					"(default=0) Set to 1, 2, 3 for increasing levels of debug information" +
+					" when this routing spec is run."),
+				new PropertySpec("updatePlatformStatus", PropertySpec.BOOLEAN,
+					"(default=true) set to false to NOT update platform status records as messages are processed."),
+				new PropertySpec("purgeOldEvents", PropertySpec.BOOLEAN,
+					"(default=true) Set to false to tell this routing spec to NOT attempt to "
+					+ "purge expired events from the database. Also see DecodesSettings.eventPurgeDays")
+			};
 		}
-		else if (className.equalsIgnoreCase("decodes.tsdb.algo.PythonAlgorithm"))
+		else if (PythonAlgorithm.class.getName().equalsIgnoreCase(className))
+		{
 			return new PropertySpec[0];
-		else if (className.equalsIgnoreCase("decodes.cwms.rating.CwmsRatingSingleIndep"))
-		{
-			PropertySpec[] specs =
-				{
-					new PropertySpec("templateVersion", PropertySpec.STRING,
-						"(default=USGS-EXSA) Used as the version part of the rating template string"),
-					new PropertySpec("specVersion", PropertySpec.STRING,
-						"(default=Production) Used as the version part of the rating spec."),
-					new PropertySpec("useDepLocation", PropertySpec.BOOLEAN,
-						"(default=false) false means use location from first INdep param. "
-						+ "True means use location from DEP param.")
-				};
-			return specs;
 		}
-		else if (className.equalsIgnoreCase("decodes.cwms.rating.CwmsRatingSingleIndep")
-			|| className.equalsIgnoreCase("decodes.cwms.rating.CwmsRatingMultiIndep"))
+		else if (CwmsRatingSingleIndep.class.getName().equalsIgnoreCase(className))
 		{
-			PropertySpec[] specs =
-				{
-					new PropertySpec("templateVersion", PropertySpec.STRING,
-						"(default=USGS-EXSA) Used as the version part of the rating template string"),
-					new PropertySpec("specVersion", PropertySpec.STRING,
-						"(default=Production) Used as the version part of the rating spec."),
-					new PropertySpec("useDepLocation", PropertySpec.BOOLEAN,
-						"(default=false) false means use location from first INdep param. "
-						+ "True means use location from DEP param.")
-				};
-			return specs;
+			return new PropertySpec[]{
+				new PropertySpec("templateVersion", PropertySpec.STRING,
+					"(default=USGS-EXSA) Used as the version part of the rating template string"),
+				new PropertySpec("specVersion", PropertySpec.STRING,
+					"(default=Production) Used as the version part of the rating spec."),
+				new PropertySpec("useDepLocation", PropertySpec.BOOLEAN,
+					"(default=false) false means use location from first INdep param. "
+					+ "True means use location from DEP param.")
+			};
 		}
+		return getPropertySpecsReflect(className);
+	}
+
+	private static PropertySpec[] getPropertySpecsReflect(String className) throws WebAppException
+	{
 		// The above special cases failed. Try to instantiate an object and ask it for
 		// its prop specs.
 		PropertiesOwner pw = null;
 		try
 		{
-			if (className.equalsIgnoreCase("decodes.db.ConfigSensor"))
-				pw = new decodes.db.ConfigSensor(null, 0);
-			else if (className.equalsIgnoreCase("decodes.consumer.StringBufferConsumer"))
-				pw = new decodes.consumer.StringBufferConsumer(new StringBuffer());
+			if(ConfigSensor.class.getName().equalsIgnoreCase(className))
+			{
+				pw = new ConfigSensor(null, 0);
+			}
+			else if(StringBufferConsumer.class.getName().equalsIgnoreCase(className))
+			{
+				pw = new StringBufferConsumer(new StringBuffer());
+			}
 			else
 			{
 				Class<?> c = Class.forName(className);
-				pw = (PropertiesOwner)c.newInstance();
+				Constructor<?>[] constructors = c.getConstructors();
+				for(Constructor<?> ctor : constructors)
+				{
+					if(ctor.getParameterCount() == 0)
+					{
+
+						pw = (PropertiesOwner) ctor.newInstance();
+					}
+					else if(ctor.getParameterCount() == 2
+							&& ctor.getParameterTypes()[0] == DataSource.class
+							&& ctor.getParameterTypes()[1] == Database.class)
+					{
+						pw = (PropertiesOwner) ctor.newInstance(null, null);
+					}
+					if(pw != null)
+					{
+						break;
+					}
+				}
+			}
+			if(pw == null)
+			{
+				throw new WebAppException(HttpServletResponse.SC_CONFLICT, "Cannot get property specs for '" + className + "'");
 			}
 			return pw.getSupportedProps();
 		}
-		catch (Exception ex)
+		catch (RuntimeException | InstantiationException | IllegalAccessException | InvocationTargetException | ClassNotFoundException ex)
 		{
 			throw new WebAppException(HttpServletResponse.SC_CONFLICT, "Cannot get property specs for '" + className + "'", ex);
 		}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelper.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelper.java
@@ -178,7 +178,7 @@ public final class PropSpecHelper
 	public static ApiPropSpec[] getPropSpecs(String className)
 			throws WebAppException
 	{
-		PropertySpec[] ps = gedecodesPropSpecs(className);
+		PropertySpec[] ps = getDecodesPropSpecs(className);
 		ApiPropSpec[] ret = new ApiPropSpec[ps.length];
 		for(int i = 0; i < ps.length; i++)
 			ret[i] = new ApiPropSpec(ps[i].getName(), ps[i].getType(), ps[i].getDescription());
@@ -186,7 +186,7 @@ public final class PropSpecHelper
 	}
 
 
-	private static PropertySpec[] gedecodesPropSpecs(String className) throws WebAppException
+	private static PropertySpec[] getDecodesPropSpecs(String className) throws WebAppException
 	{
 		//className is user controlled, so it is logged at trace level.
 		LOGGER.trace("PropSpecHelper.getPropSpecs class='{}'", className);
@@ -304,16 +304,16 @@ public final class PropSpecHelper
 	{
 		// The above special cases failed. Try to instantiate an object and ask it for
 		// its prop specs.
-		PropertiesOwner pw = null;
+		PropertiesOwner propertiesOwner = null;
 		try
 		{
 			if(ConfigSensor.class.getName().equalsIgnoreCase(className))
 			{
-				pw = new ConfigSensor(null, 0);
+				propertiesOwner = new ConfigSensor(null, 0);
 			}
 			else if(StringBufferConsumer.class.getName().equalsIgnoreCase(className))
 			{
-				pw = new StringBufferConsumer(new StringBuffer());
+				propertiesOwner = new StringBufferConsumer(new StringBuffer());
 			}
 			else
 			{
@@ -324,25 +324,25 @@ public final class PropSpecHelper
 					if(ctor.getParameterCount() == 0)
 					{
 
-						pw = (PropertiesOwner) ctor.newInstance();
+						propertiesOwner = (PropertiesOwner) ctor.newInstance();
 					}
 					else if(ctor.getParameterCount() == 2
 							&& ctor.getParameterTypes()[0] == DataSource.class
 							&& ctor.getParameterTypes()[1] == Database.class)
 					{
-						pw = (PropertiesOwner) ctor.newInstance(null, null);
+						propertiesOwner = (PropertiesOwner) ctor.newInstance(null, null);
 					}
-					if(pw != null)
+					if(propertiesOwner != null)
 					{
 						break;
 					}
 				}
 			}
-			if(pw == null)
+			if(propertiesOwner == null)
 			{
 				throw new WebAppException(HttpServletResponse.SC_CONFLICT, "Cannot get property specs for '" + className + "'");
 			}
-			return pw.getSupportedProps();
+			return propertiesOwner.getSupportedProps();
 		}
 		catch (RuntimeException | InstantiationException | IllegalAccessException | InvocationTargetException | ClassNotFoundException ex)
 		{

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
@@ -31,17 +31,16 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import decodes.tsdb.DbIoException;
+import decodes.tsdb.TimeSeriesDb;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.media.Content;
-
-import decodes.tsdb.DbIoException;
-import decodes.tsdb.TimeSeriesDb;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opendcs.database.api.OpenDcsDatabase;
 import org.opendcs.odcsapi.beans.ApiDecodedMessage;
@@ -199,64 +198,7 @@ public final class OdcsapiResource extends OpenDcsResource
 					+ "on how to retrieve reference lists.|\n| **h**|\tA host name or IP address|\n| **l**\t"
 					+ "| (That’s lower case L) indicates a long string that should be displayed in a "
 					+ "multi-line text area with an optional scroll bar. But be aware that most of the "
-					+ "property tables in the database limit a property value to 240 chars.|\n\n"
-					+ "The following class names currently support property specs. More may be added in the future:  \n\n"
-					+ "*\tdecodes.comp.AreaRatingCompResolver\n*\tdecodes.comp.RdbRatingCompResolver\n"
-					+ "*\tdecodes.comp.StationExcludeCompResolver\n*\tdecodes.comp.TabRatingCompResolver\n"
-					+ "*\tdecodes.consumer.DirectoryConsumer\n*\tdecodes.consumer.FileAppendConsumer\n"
-					+ "*\tdecodes.consumer.FileConsumer\n*\tdecodes.consumer.PipeConsumer\n"
-					+ "*\tdecodes.consumer.StringBufferConsumer\n*\tdecodes.consumer.TcpClientConsumer\n"
-					+ "*\tdecodes.consumer.AlbertaLoaderFormatter\n*\tcovesw.azul.consumer.CsvFormatter\n"
-					+ "*\tdecodes.consumer.EmitAsciiFormatter\n*\tdecodes.consumer.EmitOracleFormatter\n"
-					+ "*\tdecodes.consumer.HeaderFormatter\n*\tdecodes.consumer.HtmlFormatter\n"
-					+ "*\tdecodes.consumer.HumanReadableFormatter\n*\tdecodes.consumer.HydroJSONFormatter\n"
-					+ "*\tdecodes.consumer.KHydstraFormatter\n*\tdecodes.consumer.KistersFormatter\n"
-					+ "*\tdecodes.consumer.NullFormatter\n*\tdecodes.consumer.RawFormatter\n"
-					+ "*\tdecodes.consumer.ShefFormatter\n*\tdecodes.consumer.ShefitFormatter\n"
-					+ "*\tdecodes.consumer.TransmitMonitorFormatter\n*\tdecodes.consumer.TsImportFormatter\n"
-					+ "*\tdecodes.cwms.CwmsConsumer\n*\tdecodes.datasource.DirectoryDataSource\n"
-					+ "*\tdecodes.datasource.FtpDataSource\n*\tdecodes.datasource.HotBackupGroup\n"
-					+ "*\tdecodes.datasource.LrgsDataSource\n*\tdecodes.datasource.RoundRobinGroup\n"
-					+ "*\tdecodes.datasource.ScpDataSource\n*\tdecodes.datasource.SocketStreamDataSource\n"
-					+ "*\tdecodes.datasource.UsgsWebDataSource\n*\tdecodes.datasource.WebAbstractDataSource\n"
-					+ "*\tdecodes.datasource.WebDataSource\n*\tdecodes.datasource.WebDirectoryDataSource\n"
-					+ "*\tdecodes.polling.PollingDataSource\n*\tdecodes.db.Platform\n*\tdecodes.db.PlatformSensor\n"
-					+ "*\tdecodes.db.ConfigSensor\n*\tdecodes.routing.RoutingScheduler\n*\tdecodes.tsdb.CompAppInfo\n"
-					+ "*\tdecodes.tsdb.algo.HdbRating\n*\tdecodes.tsdb.algo.RunningAverageAlgorithm\n"
-					+ "*\tdecodes.tsdb.algo.AverageAlgorithm\n*\tdecodes.tsdb.algo.BigAdder\n"
-					+ "*\tdecodes.tsdb.algo.Multiplication\n*\tdecodes.tsdb.algo.SumOverTimeAlgorithm\n"
-					+ "*\tdecodes.tsdb.algo.ExpressionParserAlgorithm\n*\tdecodes.tsdb.algo.FillForward\n"
-					+ "*\tdecodes.tsdb.algo.HdbReservoirMassBalance\n*\tdecodes.tsdb.algo.AddToPrevious\n"
-					+ "*\tdecodes.tsdb.algo.Stat\n*\tdecodes.tsdb.algo.HdbEvaporation\n"
-					+ "*\tdecodes.tsdb.algo.EstimatedInflow\n*\tdecodes.tsdb.algo.GroupAdder\n"
-					+ "*\tdecodes.tsdb.algo.ReservoirFull\n*\tdecodes.tsdb.algo.ScalerAdder\n"
-					+ "*\tdecodes.tsdb.algo.HdbACAPSRating\n*\tdecodes.tsdb.algo.ChooseOne\n"
-					+ "*\tdecodes.tsdb.algo.BridgeClearance\n*\tdecodes.tsdb.algo.UsgsEquation\n"
-					+ "*\tdecodes.tsdb.algo.IncrementalPrecip\n*\tdecodes.tsdb.algo.FlowResIn\n"
-					+ "*\tdecodes.tsdb.algo.CopyAlgorithm\n*\tdecodes.tsdb.algo.DisAggregate\n"
-					+ "*\tdecodes.tsdb.algo.WeightedWaterTemperature\n*\tdecodes.tsdb.algo.PythonAlgorithm\n"
-					+ "*\tdecodes.tsdb.algo.Resample\n*\tdecodes.tsdb.algo.ShowAlgoProps\n"
-					+ "*\tdecodes.tsdb.algo.PeriodToDate\n*\tdecodes.tsdb.algo.CopyNoOverwrite\n"
-					+ "*\tdecodes.tsdb.algo.SubSample\n*\tdecodes.tsdb.algo.CentralRunningAverageAlgorithm\n"
-					+ "*\tdecodes.tsdb.algo.TabRating\n*\tdecodes.tsdb.algo.RdbRating\n"
-					+ "*\tdecodes.tsdb.algo.Division\n*\tdecodes.tsdb.algo.VirtualGage\n"
-					+ "*\tdecodes.tsdb.alarm.AlarmScreeningAlgorithm\n*\tdecodes.hdb.algo.InflowAdvancedAlg\n*"
-					+ "\tdecodes.hdb.algo.EquationSolverAlg\n*\tdecodes.hdb.algo.EstGLDAInflow\n"
-					+ "*\tdecodes.hdb.algo.BeginofPeriodAlg\n*\tdecodes.hdb.algo.DynamicAggregatesAlg\n"
-					+ "*\tdecodes.hdb.algo.HdbShiftRating\n*\tdecodes.hdb.algo.HdbLookupTimeShiftRating\n"
-					+ "*\tdecodes.hdb.algo.SideInflowAlg\n*\tdecodes.hdb.algo.VolumeToFlowAlg\n"
-					+ "*\tdecodes.hdb.algo.NVRNUnreg\n*\tdecodes.hdb.algo.PowerToEnergyAlg\n"
-					+ "*\tdecodes.hdb.algo.GLDAUnreg\n*\tdecodes.hdb.algo.CallProcAlg\n"
-					+ "*\tdecodes.hdb.algo.EndofPeriodAlg\n*\tdecodes.hdb.algo.GLDAEvap\n"
-					+ "*\tdecodes.hdb.algo.BMDCUnreg\n*\tdecodes.hdb.algo.CRRCUnreg\n"
-					+ "*\tdecodes.hdb.algo.ParshallFlume\n*\tdecodes.hdb.algo.FlowToVolumeAlg\n"
-					+ "*\tdecodes.hdb.algo.SimpleDisaggAlg\n*\tdecodes.hdb.algo.EOPInterpAlg\n"
-					+ "*\tdecodes.hdb.algo.TimeWeightedAverageAlg\n*\tdecodes.hdb.algo.InflowBasicAlg\n"
-					+ "*\tdecodes.hdb.algo.MPRCUnreg\n*\tdecodes.hdb.algo.GlenDeltaBSMBAlg\n"
-					+ "*\tdecodes.hdb.algo.FLGUUnreg\n*\tdecodes.cwms.rating.CwmsRatingSingleIndep\n"
-					+ "*\tdecodes.cwms.rating.CwmsRatingMultIndep\n*\tdecodes.cwms.validation.ScreeningAlgorithm\n"
-					+ "*\tdecodes.util.DecodesSettings\n*\tlrgs.lrgsmain.LrgsConfig\n"
-					+ "*\topendcs.opentsdb.OpenTsdbSettings",
+					+ "property tables in the database limit a property value to 240 chars.|",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "Success. Property specifications retrieved.",
 						content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -267,16 +209,20 @@ public final class OdcsapiResource extends OpenDcsResource
 			},
 			tags = {"REST - Retrieving Property Specs"}
 	)
-	public Response getPropSpecs(@Parameter(description = "Fully Qualified Class Name", required = true,
-			example = "decodes.db.Platform", schema = @Schema(implementation = String.class))
+	public Response getPropSpecs(@Parameter(description = "Fully Qualified Class Name",
+			required = true,
+			schema = @Schema(type = "string",
+					enumAsRef = true,
+					implementation = PropSpecHelper.ClassName.class
+			)
+	)
 		@QueryParam("class") String className)
 			throws WebAppException
 	{
 		if (className == null)
 		{
-			throw new MissingParameterException("Missing required class argument.");
+			throw new MissingParameterException("Missing required 'class' argument.");
 		}
-
 		return Response.status(HttpServletResponse.SC_OK).entity(PropSpecHelper.getPropSpecs(className)).build();
 	}
 

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelperTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelperTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2025 OpenDCS Consortium and its Contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opendcs.odcsapi.opendcs_dep;
+
+import java.util.stream.Stream;
+
+import decodes.db.Database;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opendcs.odcsapi.beans.ApiPropSpec;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+final class PropSpecHelperTest
+{
+
+	@ParameterizedTest
+	@MethodSource("classNames")
+	void testPropSpecClasses(String className)
+	{
+		Database db = Database.getDb();
+		if(db == null)
+		{
+			//Workaround for PMParser using global instance
+			Database.setDb(new Database());
+		}
+		ApiPropSpec[] apiPropSpecs = assertDoesNotThrow(() -> PropSpecHelper.getPropSpecs(className), "Failed to get prop specs for " + className);
+		assertNotNull(apiPropSpecs, "Prop specs for " + className + " is null");
+	}
+
+	static Stream<String> classNames()
+	{
+		return Stream.of(PropSpecHelper.ClassName.values()).map(Object::toString);
+	}
+}

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelperTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/opendcs_dep/PropSpecHelperTest.java
@@ -18,6 +18,8 @@ package org.opendcs.odcsapi.opendcs_dep;
 import java.util.stream.Stream;
 
 import decodes.db.Database;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opendcs.odcsapi.beans.ApiPropSpec;
@@ -28,16 +30,30 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 final class PropSpecHelperTest
 {
 
-	@ParameterizedTest
-	@MethodSource("classNames")
-	void testPropSpecClasses(String className)
+	private Database oldDb;
+
+	@BeforeEach
+	void setup()
 	{
-		Database db = Database.getDb();
-		if(db == null)
+
+		oldDb = Database.getDb();
+		if(oldDb == null)
 		{
 			//Workaround for PMParser using global instance
 			Database.setDb(new Database());
 		}
+	}
+
+	@AfterEach
+	void tearDown()
+	{
+		Database.setDb(oldDb);
+	}
+
+	@ParameterizedTest
+	@MethodSource("classNames")
+	void testPropSpecClasses(String className)
+	{
 		ApiPropSpec[] apiPropSpecs = assertDoesNotThrow(() -> PropSpecHelper.getPropSpecs(className), "Failed to get prop specs for " + className);
 		assertNotNull(apiPropSpecs, "Prop specs for " + className + " is null");
 	}


### PR DESCRIPTION
## Problem Description

Fixes #389 . 

## Solution

Update reflection mechanism to use new constructors.

## how you tested the change

Unit tests and by running the webapp in embedded tomcat to check the revised Swagger page.

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [X] Were relevant config element (e.g. XML data) updated as appropriate

