### PR TITLE
fix swagger page to use the current API context

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OpenDcsResource.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OpenDcsResource.java
@@ -32,10 +32,8 @@ import static org.opendcs.odcsapi.res.DataSourceContextCreator.DATA_SOURCE_ATTRI
 @OpenAPIDefinition(
 		info = @Info(
 				title = "OpenDCS - Swagger",
-				description = "OpenDCS Rest API is web application that provides access to the OpenDCS database using JSON (Java Script Object Notation).\n" +
-						"    OpenDCS Rest API is intended to run as a stand-alone Java program. It uses embedded JETTY to implement the web services.\n" +
-						"    It was developed for the U. S. Army Corps of Engineers. Source and documentation may be found here:\n" +
-						"    [Github Documentation](https://github.com/opendcs/rest_api)",
+				description = "OpenDCS Rest API is web application that provides access to the OpenDCS database using JSON (Java Script Object Notation). " +
+						"Source and documentation may be found here: [Github Documentation](https://github.com/opendcs/rest_api)",
 				version = "0.0.3"
 		)
 )

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RestServices.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RestServices.java
@@ -15,9 +15,18 @@
 
 package org.opendcs.odcsapi.res;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.servlet.ServletContext;
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Context;
 
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
+import io.swagger.v3.oas.integration.SwaggerConfiguration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,11 +36,29 @@ public final class RestServices extends ResourceConfig
 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RestServices.class);
 
-	public RestServices()
+	;
+
+	public RestServices(@Context ServletContext servletContext)
 	{
 		LOGGER.debug("Initializing odcsapi RestServices.");
 		packages("org.opendcs.odcsapi");
+		setupSwagger(servletContext);
+	}
 
-		register(OpenApiResource.class);
+	private void setupSwagger(ServletContext servletContext)
+	{
+		Set<String> resourcePackages = new HashSet<>();
+		resourcePackages.add("org.opendcs.odcsapi");
+		List<Server> servers = new ArrayList<>();
+		String contextPath = servletContext.getContextPath();
+		servers.add(new Server().url(contextPath));
+		OpenAPI openAPI = new OpenAPI();
+		openAPI.setServers(servers);
+		SwaggerConfiguration swaggerConfig = new SwaggerConfiguration();
+		swaggerConfig.setResourcePackages(resourcePackages);
+		swaggerConfig.setOpenAPI(openAPI);
+		OpenApiResource openApiResource = new OpenApiResource();
+		openApiResource.setOpenApiConfiguration(swaggerConfig);
+		register(openApiResource);
 	}
 }


### PR DESCRIPTION
## Problem Description

The Swagger try-it-out feature does not work if the REST API context is not the root.

## Solution

Add the API context to the swagger servers list.

## how you tested the change

Tested running the embedded Tomcat app.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

