### PR TITLE
fix swagger link in the gui footer

### DIFF
--- a/doc-source/Swagger-README.md
+++ b/doc-source/Swagger-README.md
@@ -10,7 +10,7 @@ resources and their functionality in a user-friendly manner.
 
 To view the API specification, navigate to the Swagger UI located at:
 ```
-https://[REST_API_URL]/odcsapi/swaggerui/index.html
+https://<host>:<port>/[REST_API_CONTEXT]/swaggerui/index.html
 ```
 
 On development machines running the REST API locally, this will be located at 

--- a/opendcs-web-client/src/main/webapp/resources/jsp/footers/decodes.jsp
+++ b/opendcs-web-client/src/main/webapp/resources/jsp/footers/decodes.jsp
@@ -28,13 +28,29 @@
 		<span class="navbar-text"><a href="#">OpenDCS Web</a> </span>
 
 		<ul class="navbar-nav ml-lg-auto">
-
-			<li class="nav-item"><a
-				href="<% String swaggerUrl =  (String) request.getAttribute("api_swaggerui_url"); %><%= swaggerUrl %>"
-				class="nav-link" target="_blank" rel="noopener"> <i class="icon-code"></i> <span>
-						API Swagger UI </span>
-			</a>
+			<li class="nav-item">
+				<a id="swagger-link"
+				   href="#"
+				   class="nav-link"
+				   target="_blank"
+				   rel="noopener">
+					<i class="icon-code"></i>
+					<span>API Swagger UI </span>
+				</a>
 		</ul>
 	</div>
 </div>
+<script>
+	document.addEventListener("DOMContentLoaded", function() {
+		const apiUrl = window.API_URL || '';
+		const swaggerLink = document.getElementById("swagger-link");
+
+		if (apiUrl) {
+			swaggerLink.href = apiUrl + `/swaggerui/index.html`;
+		} else {
+			console.warn("API_URL is not defined");
+		}
+	});
+</script>
+
 <%-- /footer --%>


### PR DESCRIPTION
## Problem Description

Fixes #403 . 

Swagger link goes to /portal/null instead of swagger page

## Solution

Route to <rest-api-context>/swaggerui/index.html

## how you tested the change

Test via gradle run task.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [X] Was relevant documentation updated?
- [X] Were relevant config element (e.g. XML data) updated as appropriate

