### PR TITLE
fix null pointer when storing platform sensors

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
@@ -367,6 +367,7 @@ public final class PlatformResources extends OpenDcsResource
 		ret.setPlatformDesignator(platform.getDesignator());
 		ret.lastModifyTime = new Date();
 		ret.platformSensors = platMap(platform.getPlatformSensors());
+		ret.platformSensors.forEach(p -> p.platform = ret);
 		if (platform.getConfigId() != null)
 		{
 			PlatformConfig config = new PlatformConfig();

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/PlatformResourcesTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/PlatformResourcesTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -362,6 +363,7 @@ final class PlatformResourcesTest
 		assertMatch(plat.getPlatformSensors(), result.getPlatformSensors());
 		assertMatchMedium(plat.getTransportMedia(), result.getTransportMedia());
 		assertEquals(plat.getProperties(), result.getProperties());
+		result.platformSensors.forEach(s -> assertSame(result, s.platform));
 	}
 
 	private static void assertMatch(List<ApiPlatformSensor> apiPlatformSensors, Iterator<PlatformSensor> platformSensors)


### PR DESCRIPTION
platform sensors need to reference their platform

## Problem Description

Storing a new platform sensor throws a null pointer.

## Solution

Make sure the platform sensors reference their platform.

## how you tested the change

Unit tests.

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

