### PR TITLE
add auth to all calls except login/logout

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ jersey = "2.40"
 
 swagger = "2.2.28"
 swagger-ui = "5.18.3"
+swagger-parser = "2.1.25"
 jackson = "2.18.2"
 selenium = "3.141.59"
 nimbus = "9.41.1"
@@ -62,6 +63,7 @@ tomcat-jdbc = { module = "org.apache.tomcat:tomcat-jdbc", version.ref = "tomcat"
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 commons-lang = { module = "commons-lang:commons-lang", version.ref = "commons-lang" }
 slf4j-jdk14 = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j"}
+swagger-parser = { module = "io.swagger.parser.v3:swagger-parser-v3", version.ref = "swagger-parser"}
 
 # webjars
 swagger-ui = { module ="org.webjars:swagger-ui", version.ref = "swagger-ui" }

--- a/opendcs-integration-test/build.gradle
+++ b/opendcs-integration-test/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation(libs.hamcrest)
     testImplementation(libs.nimbus)
     testImplementation(libs.jwt)
+    testImplementation(libs.swagger.parser)
     testRuntimeOnly(libs.byte.buddy)
     testRuntimeOnly(libs.junit.api)
     testRuntimeOnly(libs.junit.engine)

--- a/opendcs-integration-test/src/test/java/org/opendcs/odcsapi/res/it/AlgorithmResourcesIT.java
+++ b/opendcs-integration-test/src/test/java/org/opendcs/odcsapi/res/it/AlgorithmResourcesIT.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.MediaType;
 
 import io.restassured.filter.log.LogDetail;
 import io.restassured.filter.session.SessionFilter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,10 +36,19 @@ import static org.hamcrest.Matchers.is;
 final class AlgorithmResourcesIT extends BaseIT
 {
 
+	private SessionFilter sessionFilter;
+
+	@BeforeEach
+	void setUp() throws Exception
+	{
+		setUpCreds();
+		sessionFilter = new SessionFilter();
+		authenticate(sessionFilter);
+	}
+
 	@TestTemplate
 	void getAlgorithmRefs()
 	{
-		SessionFilter sessionFilter = new SessionFilter();
 		given()
 			.log().ifValidationFails(LogDetail.ALL, true)
 			.accept(MediaType.APPLICATION_JSON)
@@ -61,7 +71,6 @@ final class AlgorithmResourcesIT extends BaseIT
 		ApiAlgorithm dto = getDtoFromResource("algorithm_tempstring_check.json", ApiAlgorithm.class);
 		//The ID can't be set as it is generated on store
 		dto.setAlgorithmId(null);
-		SessionFilter sessionFilter = new SessionFilter();
 		authenticate(sessionFilter);
 		//Assert algorithm can be stored. Update with the new id
 		dto = given()

--- a/opendcs-integration-test/src/test/java/org/opendcs/odcsapi/sec/AuthorizationTestIT.java
+++ b/opendcs-integration-test/src/test/java/org/opendcs/odcsapi/sec/AuthorizationTestIT.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2025 OpenDCS Consortium and its Contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.opendcs.odcsapi.sec;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.servlet.http.HttpServletResponse;
+
+import io.restassured.RestAssured;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.filter.session.SessionFilter;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opendcs.odcsapi.fixtures.DatabaseContextProvider;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Tag("integration")
+@ExtendWith(DatabaseContextProvider.class)
+final class AuthorizationTestIT
+{
+
+	@TestTemplate
+	void unauthorizedAccessShouldReturn401()
+	{
+		assertAll(getEndpoints().map(endpoint -> () ->
+		{
+			String path = endpoint.path;
+			PathItem.HttpMethod method = endpoint.method;
+			String acceptMediaType = endpoint.acceptMediaType;
+			String contentMediaType = endpoint.contentMediaType;
+			RequestSpecification spec = given()
+					.accept(acceptMediaType)
+					.contentType(contentMediaType)
+					//ensures unauthorized session
+					.filter(new SessionFilter())
+					.when();
+			Response response;
+			switch(method)
+			{
+				case GET:
+					response = spec.get(path);
+					break;
+				case POST:
+					response = spec.post(path);
+					break;
+				case PUT:
+					response = spec.put(path);
+					break;
+				case DELETE:
+					response = spec.delete(path);
+					break;
+				default:
+					throw new IllegalArgumentException("Unsupported method: " + method);
+			}
+			response.then()
+					.log().ifValidationFails(LogDetail.ALL, true)
+					.assertThat()
+					.statusCode(HttpServletResponse.SC_UNAUTHORIZED);
+		}));
+	}
+
+
+	private static Stream<Endpoint> getEndpoints()
+	{
+		OpenAPIV3Parser parser = new OpenAPIV3Parser();
+		OpenAPI api = parser.read(RestAssured.baseURI + ":" + RestAssured.port + "/" + RestAssured.basePath + "/openapi.json");
+		Paths paths = api.getPaths();
+		return paths.entrySet().stream()
+				.filter(e -> !e.getKey().equals("/credentials"))
+				.filter(e -> !e.getKey().equals("/logout"))
+				.flatMap(e ->
+						e.getValue().readOperationsMap().entrySet().stream().map(opEntry ->
+						{
+							String contentType = javax.ws.rs.core.MediaType.APPLICATION_JSON;
+							RequestBody requestBody = opEntry.getValue().getRequestBody();
+							if(requestBody != null)
+							{
+								contentType = requestBody.getContent().keySet().iterator().next();
+							}
+							List<ApiResponse> acceptTypes = new ArrayList<>(opEntry.getValue().getResponses().values());
+							Content acceptContent = acceptTypes.get(0).getContent();
+							String acceptType = javax.ws.rs.core.MediaType.APPLICATION_JSON;
+							if(acceptContent != null)
+							{
+								acceptType = acceptContent.keySet().iterator().next();
+							}
+							return new Endpoint(e.getKey(), opEntry.getKey(), contentType, acceptType);
+						}));
+	}
+
+	private static class Endpoint
+	{
+		private final String path;
+		private final PathItem.HttpMethod method;
+		public final String contentMediaType;
+		public final String acceptMediaType;
+
+		private Endpoint(String path, PathItem.HttpMethod method, String contentMediaType, String acceptMediaType)
+		{
+			this.path = path;
+			this.method = method;
+			this.contentMediaType = contentMediaType;
+			this.acceptMediaType = acceptMediaType;
+		}
+
+		@Override
+		public String toString()
+		{
+			return path + " " + method;
+		}
+	}
+}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AlgorithmResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AlgorithmResources.java
@@ -188,7 +188,7 @@ public final class AlgorithmResources extends OpenDcsResource
 	@Path("algorithm")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing OpenDCS Algorithm",
 			description = "It takes a single OpenDCS Algorithm Record in JSON format, as described above for GET.   \n\n"
@@ -255,7 +255,7 @@ public final class AlgorithmResources extends OpenDcsResource
 	@Path("algorithm")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing OpenDCS Algorithm",
 			description = "Required argument algorithmid must be passed in the URL.  \n\n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AlgorithmResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AlgorithmResources.java
@@ -67,7 +67,7 @@ public final class AlgorithmResources extends OpenDcsResource
 	@GET
 	@Path("algorithmrefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed(ApiConstants.ODCS_API_GUEST)
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve all algorithm references",
 			description = "Example: \n\n    http://localhost:8080/odcsapi/algorithmrefs",
@@ -108,7 +108,7 @@ public final class AlgorithmResources extends OpenDcsResource
 	@GET
 	@Path("algorithm")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed(ApiConstants.ODCS_API_GUEST)
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve an algorithm by its ID",
 			description = "Example: \n\n    http://localhost:8080/odcsapi/algorithm?algorithmid=4",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -156,7 +156,7 @@ public final class AppResources extends OpenDcsResource
 	@Path("app")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing App",
 			description = "The App POST method takes a single DECODES Loading Application in JSON format, "
@@ -228,7 +228,7 @@ public final class AppResources extends OpenDcsResource
 	@Path("app")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Loading App",
 			description = "Required argument appid must be passed in the URL.  \n\n"
@@ -277,7 +277,7 @@ public final class AppResources extends OpenDcsResource
 	@GET
 	@Path("appstat")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Returns an array with one element for each application",
 			description = "REST - Loading Application Records describes API methods for retrieving and manipulating "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/AppResources.java
@@ -71,7 +71,7 @@ public final class AppResources extends OpenDcsResource
 	@GET
 	@Path("apprefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieves a list of application references",
 			description = "Example:  \n\n    http://localhost:8080/odcsapi/apprefs",
@@ -114,7 +114,7 @@ public final class AppResources extends OpenDcsResource
 	@GET
 	@Path("app")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve a Single Application by its ID",
 			description = "Example: \n\n    http://localhost:8080/odcsapi/app?appid=4  \n",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -310,7 +310,7 @@ public final class ComputationResources extends OpenDcsResource
 	@Path("computation")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing OpenDCS Computation",
 			description = "The Computation POST method takes a single OpenDCS Computation Record in JSON format,"
@@ -451,7 +451,7 @@ public final class ComputationResources extends OpenDcsResource
 	@Path("computation")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing OpenDCS Computation",
 			description = "Required argument computationid must be passed in the URL.",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ComputationResources.java
@@ -71,7 +71,7 @@ public final class ComputationResources extends OpenDcsResource
 	@GET
 	@Path("computationrefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve Computation References",
 			description = "Example:  \n\n    http://localhost:8080/odcsapi/computationrefs",
@@ -173,7 +173,7 @@ public final class ComputationResources extends OpenDcsResource
 	@GET
 	@Path("computation")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve Computation by its ID",
 			description = "Example: \n\n    http://localhost:8080/odcsapi/computation?computationid=4",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
@@ -271,7 +271,7 @@ public final class ConfigResources extends OpenDcsResource
 	@Path("config")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Config",
 			description = "The POST config method takes a single DECODES Platform Configuration record in JSON format, "
@@ -480,7 +480,7 @@ public final class ConfigResources extends OpenDcsResource
 	@Path("config")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Config",
 			description = "Required argument configid must be passed.  \n\n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
@@ -111,7 +111,7 @@ public final class ConfigResources extends OpenDcsResource
 			},
 			tags = {"REST - DECODES Platform Configurations"}
 	)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	public Response getConfigRefs() throws DbException
 	{
 		DatabaseIO dbIo = getLegacyDatabase();
@@ -156,7 +156,7 @@ public final class ConfigResources extends OpenDcsResource
 	@GET
 	@Path("config")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON representation of a single, complete DECODES Config record",
 			description = "Example:  \n\n    http://localhost:8080/odcsapi/config?configid=12\n\n\n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
@@ -253,7 +253,7 @@ public class DataSourceResources extends OpenDcsResource
 	@Path("datasource")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Data Source",
 			description = "The POST datasource method takes a single datasource in JSON format, as described for the GET method." +
@@ -347,7 +347,7 @@ public class DataSourceResources extends OpenDcsResource
 	@Path("datasource")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Data Source",
 			description = "Required argument datasourceid must be passed. " +

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DataSourceResources.java
@@ -69,7 +69,7 @@ public class DataSourceResources extends OpenDcsResource
 	@GET
 	@Path("datasourcerefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON list of DECODES Data Source records suitable for displaying in a table or pick-list",
 			description = "Example: \n\n`http://localhost:8080/odcsapi/datasourcerefs`\n\n" +
@@ -138,7 +138,7 @@ public class DataSourceResources extends OpenDcsResource
 	@GET
 	@Path("datasource")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The GET datasource method returns a single DECODES data source with all of its detail.",
 			description = "The integer argument datasourceid is required.\n Example: " +

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
@@ -79,7 +79,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@GET
 	@Path("datatypelist")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve Data Type List",
 			description = "Examples:  \n\n    http://localhost:8080/odcsapi/datatypelist  \n\n    " 
@@ -147,7 +147,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@GET
 	@Path("unitlist")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Engineering Unit Methods")
 	@Operation(
 			summary = "Returns an array of data structures representing all known Engineering Units",
@@ -306,7 +306,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@GET
 	@Path("euconvlist")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Engineering Unit Methods")
 	@Operation(
 			summary = "Returns a list of Engineering Unit Conversions defined in the database",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
@@ -212,7 +212,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@Path("eu")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Engineering Unit Methods")
 	@Operation(
 			summary = "Create a new, or update an existing Engineering Unit",
@@ -264,7 +264,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@Path("eu")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Engineering Unit Methods")
 	@Operation(
 			summary = "Delete an existing Engineering Unit",
@@ -363,7 +363,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@Path("euconv")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create a new, or update an existing Engineering Unit Conversion",
 			description = "Example URL for POST:  \n\n    "
@@ -499,7 +499,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 	@Path("euconv")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Engineering Unit Methods")
 	@Operation(
 			summary = "Delete an existing Engineering Unit conversion record",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
@@ -72,7 +72,7 @@ public final class NetlistResources extends OpenDcsResource
 	@GET
 	@Path("netlistrefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The GET netlistrefs method returns references to network lists",
 			description = "The GET netlistrefs method is intended to populate a pick list of network lists and"
@@ -152,7 +152,7 @@ public final class NetlistResources extends OpenDcsResource
 	@GET
 	@Path("netlist")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The ‘netlists’ GET method will return a specific network list in its entirety.",
 			description = "Example:\n\n    http://localhost:8080/odcsapi/netlist?netlistid=1",
@@ -388,7 +388,7 @@ public final class NetlistResources extends OpenDcsResource
 	@Path("cnvtnl")
 	@Consumes(MediaType.TEXT_PLAIN)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Convert Network List File",
 			description = "Parses a network list file (in text format) and converts it to an object representation.",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
@@ -230,7 +230,7 @@ public final class NetlistResources extends OpenDcsResource
 	@Path("netlist")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Network Lists", description = "A Network List is simply a list of Platforms.")
 	@Operation(
 			summary = "Create or Overwrite Existing Netlist",
@@ -311,7 +311,7 @@ public final class NetlistResources extends OpenDcsResource
 	@Path("netlist")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing netlists",
 			description = "Required argument netlistid must be passed.\n\n" +

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
@@ -63,7 +63,7 @@ public final class OdcsapiResource extends OpenDcsResource
 	@GET
 	@Path("tsdb_properties")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Get TSDB Properties",
 			description = "Example:  \n\n    http://localhost:8080/odcsapi/tsdb_properties  \n    \n    \n"
@@ -161,7 +161,7 @@ public final class OdcsapiResource extends OpenDcsResource
 	@GET
 	@Path("propspecs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Retrieving Property Specs", description = "Many of the Java classes within OpenDCS maintain a "
 			+ "set of properties that can alter the object’s behavior. "
 			+ "This method allows the caller to get a list of acceptable properties for a given class.")

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/OdcsapiResource.java
@@ -111,7 +111,7 @@ public final class OdcsapiResource extends OpenDcsResource
 	@Path("tsdb_properties")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Update TSDB Properties",
 			description = "The POST tsdb_properties method takes one or more properties in a structure"
@@ -233,7 +233,7 @@ public final class OdcsapiResource extends OpenDcsResource
 	@Path("decode")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Decode a Message",
 			description = "Example URL for HTTP POST method:  \n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
@@ -307,7 +307,7 @@ public final class PlatformResources extends OpenDcsResource
 	@Path("platform")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Decodes Platform",
 			description = "The GET platform method takes a single DECODES Platform record in JSON format,"
@@ -477,7 +477,7 @@ public final class PlatformResources extends OpenDcsResource
 	@Path("platform")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Decodes Platform",
 			description = "Required argument platformid must be passed.",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
@@ -83,7 +83,7 @@ public final class PlatformResources extends OpenDcsResource
 	@GET
 	@Path("platformrefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The GET platformrefs method returns a list of platforms",
 			description = "The GET platformrefs method returns a list of platforms, "
@@ -184,7 +184,7 @@ public final class PlatformResources extends OpenDcsResource
 	@GET
 	@Path("platform")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON representation of a single, complete DECODES Platform record",
 			description = "Fetches detailed information about a specific platform using its unique ID. "
@@ -523,7 +523,7 @@ public final class PlatformResources extends OpenDcsResource
 	@GET
 	@Path("platformstat")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Returned structure contains information about recent activity on each platform",
 			description = "Sample URL:\n  \n    http://localhost:8080/odcsapi/platformstat  \n  \n  \n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
@@ -75,7 +75,7 @@ public final class PresentationResources extends OpenDcsResource
 	@GET
 	@Path("presentationrefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Returns a list of references to presentation groups suitable for displaying a list",
 			tags = {"REST - DECODES Presentation Group Records"},
@@ -147,7 +147,7 @@ public final class PresentationResources extends OpenDcsResource
 	@GET
 	@Path("presentation")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON representation of a single, complete DECODES Presentation Group record",
 			description = "Example: \n \n `http://localhost:8080/odcsapi/presentation?groupid=4` \n \n "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PresentationResources.java
@@ -244,7 +244,7 @@ public final class PresentationResources extends OpenDcsResource
 	@Path("presentation")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Decodes Presentation Group",
 			description = "It takes a single DECODES "
@@ -365,7 +365,7 @@ public final class PresentationResources extends OpenDcsResource
 	@Path("presentation")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Presentation Group",
 			description = "Required argument groupid must be passed in the URL.",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
@@ -208,7 +208,7 @@ public final class ReflistResources extends OpenDcsResource
 	@Path("reflist")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create New Reference List, or Overwrite Existing Reference List",
 			description = "The ‘reflist’ POST method takes a single network "
@@ -304,7 +304,7 @@ public final class ReflistResources extends OpenDcsResource
 	@Path("reflist")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Reference List",
 			description = "Required argument reflistid must be passed.  \n\n"
@@ -470,7 +470,7 @@ public final class ReflistResources extends OpenDcsResource
 	@Path("season")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Creates or overwrites a single season record",
 			description = "It takes a data structure like the one described above for GET season.",
@@ -551,7 +551,7 @@ public final class ReflistResources extends OpenDcsResource
 	@Path("season")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Season",
 			description = "The DELETE season method requires an argument"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
@@ -76,7 +76,7 @@ public final class ReflistResources extends OpenDcsResource
 	@GET
 	@Path("reflists")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "REST - Reference Lists", description = "Reference lists are used in OpenDCS to populate pulldown lists "
 			+ "and extend the functionality of the software.")
 	@Operation(
@@ -342,7 +342,7 @@ public final class ReflistResources extends OpenDcsResource
 	@GET
 	@Path("seasons")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Seasons are used in various places in OpenDCS, usually to specify some type of conditional processing",
 			description = "Seasons are denoted by an abbreviation, a full name, start date/time, end date/time, and an optional time zone."
@@ -405,7 +405,7 @@ public final class ReflistResources extends OpenDcsResource
 	@GET
 	@Path("season")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Return a single season data structure ",
 			description = "Instead of a list of seasons, the returned data is a single season data structure:  ",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RoutingResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RoutingResources.java
@@ -239,7 +239,7 @@ public final class RoutingResources extends OpenDcsResource
 	@Path("routing")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Routing Spec",
 			description = "The POST routing method takes a single DECODES Routing Spec in JSON format, "
@@ -352,7 +352,7 @@ public final class RoutingResources extends OpenDcsResource
 	@Path("routing")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Decodes Routing Spec",
 			description = "Required argument routingid must be passed in the URL.",
@@ -512,7 +512,7 @@ public final class RoutingResources extends OpenDcsResource
 	@Path("schedule")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Schedule",
 			description = "The POST schedule method takes a single DECODES Schedule Entry "
@@ -625,7 +625,7 @@ public final class RoutingResources extends OpenDcsResource
 	@Path("schedule")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Schedule",
 			description = "Required argument scheduleid must be passed in the URL.",
@@ -891,7 +891,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("dacqevents")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Returns data acquisition events stored in the DACQ_EVENT database table",
 			description = "Sample URL:\n  \n    "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RoutingResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/RoutingResources.java
@@ -93,7 +93,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("routingrefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Get Routing References",
 			description = "Retrieves a list of all routing references.",
@@ -153,7 +153,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("routing")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON representation of a single routing spec",
 			description = "Example: \n\n    http://localhost:8080/odcsapi/routing?routingid=20",
@@ -395,7 +395,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("schedulerefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Retrieve all schedule references",
 			description = "Example:  \n\n    http://localhost:8080/odcsapi/schedulerefs\n\n"
@@ -465,7 +465,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("schedule")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON representation of a single schedule entry",
 			description = "Fetches a specific schedule object based on the provided schedule ID.\n\n"
@@ -662,7 +662,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("routingstatus")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "OpenDCS Process Monitor and Control (Routing)", description = "The following methods allow a user to "
 			+ "view the status of all routing specs and to start/stop them.")
 	@Operation(
@@ -786,7 +786,7 @@ public final class RoutingResources extends OpenDcsResource
 	@GET
 	@Path("routingexecstatus")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The GET routingexecstatus method returns all of the executions for the specified schedule entry",
 			description = "Sample URL\n  \n      http://localhost:8080/odcsapi/routingexecstatus?scheduleentryid=38\n  \n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
@@ -227,7 +227,7 @@ public final class SiteResources extends OpenDcsResource
 	@Path("site")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create or Overwrite Existing Site",
 			description = "The POST `site` method takes a single DECODES site record in JSON format."
@@ -320,7 +320,7 @@ public final class SiteResources extends OpenDcsResource
 	@Path("site")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Existing Site",
 			description = "Required parameter `siteid` must be passed.",

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/SiteResources.java
@@ -71,7 +71,7 @@ public final class SiteResources extends OpenDcsResource
 	@GET
 	@Path("siterefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON list of DECODES Site records suitable for displaying in a table or pick-list.",
 			description = "The returned structure contains only the numeric ID (unique), description, and an array of site names."
@@ -128,7 +128,7 @@ public final class SiteResources extends OpenDcsResource
 	@GET
 	@Path("site")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "This method returns a JSON representation of a single, complete DECODES Site record.",
 			description = "Example:\n\n    http://localhost:8080/odcsapi/site?siteid=3\n\n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
@@ -90,7 +90,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Path("tsrefs")
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Time Series Methods")
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The tsrefs method returns a list of time series defined in the database.",
 			description = "You have the option to filter out inactive time series by passing 'active=true' argument.  \n"
@@ -300,7 +300,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@GET
 	@Path("tsdata")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The tsdata method returns data for a time series over a specified time range.",
 			description = "The method takes 3 arguments:\n"
@@ -477,7 +477,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@GET
 	@Path("intervals")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "Time Series Methods - Interval Methods", description = "Time Intervals are stored in the database "
 			+ "for OpenTSDB. They are hardcoded for CWMS and HDB.")
 	@Operation(
@@ -654,7 +654,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@GET
 	@Path("tsgrouprefs")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Tag(name = "Time Series Methods - Groups", description = "Time Series Groups are used to define a "
 			+ "set of time series identifiers")
 	@Operation(
@@ -722,7 +722,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@GET
 	@Path("tsgroup")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_GUEST})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Provide a complete definition of a single group.",
 			description = "Example URL:  \n\n    http://localhost:8080/odcsapi-0-7/tsgroup?groupid=9\n\n"

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/TimeSeriesResources.java
@@ -189,7 +189,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@GET
 	@Path("tsspec")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "The tsspec method returns a complete specification for a time series "
 					+ "identified by the 'key' parameter.",
@@ -548,7 +548,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 			},
 			tags = {"Time Series Methods - Interval Methods"}
 	)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	public Response postInterval(ApiInterval intv)
 			throws DbException
 	{
@@ -623,7 +623,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Path("interval")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete an existing Time Interval record.",
 			description = "Example URL for DELETE:  \n\n    "
@@ -855,7 +855,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Path("tsgroup")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Create a new, or update an existing time series group",
 			description = "Example URL for POST:  \n\n    "
@@ -988,7 +988,7 @@ public final class TimeSeriesResources extends OpenDcsResource
 	@Path("tsgroup")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Delete Time Series Group",
 			description = "Example URL for DELETE:  \n\n    "

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/SessionResource.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/sec/SessionResource.java
@@ -46,7 +46,7 @@ public final class SessionResource
 	@GET
 	@Path("check")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed({ApiConstants.ODCS_API_ADMIN, ApiConstants.ODCS_API_USER})
+	@RolesAllowed({ApiConstants.ODCS_API_USER, ApiConstants.ODCS_API_ADMIN})
 	@Operation(
 			summary = "Check if session authentication is valid",
 			description = "The ‘check’ GET method can be called with a configured session.",


### PR DESCRIPTION
add integration test that reads all endpoints from the OpenAPI and tests that they all throw 401 unauthorized error codes when the client is not authorized

## Problem Description

Almost (if not all) GET endpoints are public, which can potentially leak sensitive information via properties.

Fixes #189. 

## Solution

Add required authorization to all endpoints except /credentials (this is the login) and /logout

## how you tested the change

Created an integration test that scrapes the OpenAPI (which is auto generated by finding all registered endpoints) and makes a request against them for all available methods (GET/POST/DELETE/etc) and asserts that an unsessioned client will get an error code 401 response.

## Where the following done:

- [X] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [X] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [X] Were relevant config element (e.g. XML data) updated as appropriate
