### PR TITLE
update season enums to use description for name not fullName

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ReflistResources.java
@@ -388,11 +388,12 @@ public final class ReflistResources extends OpenDcsResource
 		for (EnumValue val : seasons.values())
 		{
 			ApiSeason as = new ApiSeason();
-			as.setName(val.getFullName());
+			as.setName(val.getDescription());
 			as.setAbbr(val.getValue());
 			String[] startEndTZ = val.getEditClassName().split(" ");
 			as.setStart(startEndTZ[0]);
 			as.setEnd(startEndTZ[1]);
+			as.setSortNumber(val.getSortNumber());
 			if (startEndTZ.length > 2)
 			{
 				as.setTz(startEndTZ[2]);
@@ -490,9 +491,7 @@ public final class ReflistResources extends OpenDcsResource
 			},
 			tags = {"REST - Reference Lists"}
 	)
-	public Response postSeason(@Parameter(description = "Abbreviation of the existing season to modify")
-		@QueryParam("fromabbr") String fromAbbr,
-			@Parameter(description = "Details of the new or updated season", required = true) ApiSeason season)
+	public Response postSeason(@Parameter(description = "Details of the new or updated season", required = true) ApiSeason season)
 		throws DbException
 	{
 		try (EnumDAI dai = getLegacyTimeseriesDB().makeEnumDAO())
@@ -510,12 +509,13 @@ public final class ReflistResources extends OpenDcsResource
 			{
 				dbSeasonId = dbEnum.getId();
 			}
-			if (fromAbbr != null)
+			String fromabbr = season.getFromabbr();
+			if (fromabbr != null)
 			{
-				dai.deleteEnumValue(dbSeasonId, fromAbbr);
+				dai.deleteEnumValue(dbSeasonId, fromabbr);
 			}
 			EnumValue dbSeason = map(season, dbEnum);
-			dai.writeEnumValue(dbSeasonId, dbSeason, fromAbbr, season.getSortNumber());
+			dai.writeEnumValue(dbSeasonId, dbSeason, null, season.getSortNumber());
 			return Response.status(HttpServletResponse.SC_CREATED)
 					.entity(map(dbSeason))
 					.build();
@@ -537,13 +537,6 @@ public final class ReflistResources extends OpenDcsResource
 		}
 		ret.setEditClassName(startEndTz);
 		ret.setSortNumber(season.getSortNumber());
-		return ret;
-	}
-
-	static DbEnum map(ApiSeason season, String fromAbbr)
-	{
-		DbEnum ret = new DbEnum(season.getName());
-		ret.setDefault(fromAbbr);
 		return ret;
 	}
 

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/ReflistResourcesTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/ReflistResourcesTest.java
@@ -65,7 +65,7 @@ final class ReflistResourcesTest
 		assertNotNull(seasons);
 		ApiSeason season = seasons.get(0);
 		assertEquals(enumValue.getValue(), season.getAbbr());
-		assertEquals(enumValue.getFullName(), season.getName());
+		assertEquals(enumValue.getDescription(), season.getName());
 		assertEquals(enumValue.getEditClassName(),
 				String.format("%s %s %s", season.getStart(), season.getEnd(), season.getTz()));
 	}
@@ -110,24 +110,7 @@ final class ReflistResourcesTest
 		assertEquals(season.getStart(), startEndTzArray[0]);
 		assertEquals(season.getEnd(), startEndTzArray[1]);
 		assertEquals(season.getTz(), startEndTzArray[2]);
-	}
-
-	@Test
-	void testEnumSeasonMap()
-	{
-		ApiSeason season = new ApiSeason();
-		String abbr = "m";
-		season.setAbbr(abbr);
-		season.setName("Meter");
-		season.setStart("start");
-		season.setEnd("end");
-		season.setSortNumber(1);
-		season.setTz("UTC");
-
-		DbEnum dbEnum = map(season, abbr);
-
-		assertNotNull(dbEnum);
-		assertEquals(season.getName(), dbEnum.getUniqueName());
+		assertEquals(season.getSortNumber(), result.getSortNumber());
 	}
 
 	@Test


### PR DESCRIPTION

## Problem Description

Fixes #413 .
Fixes #414  . 

## Solution

fullName appends the enum name to the description, we only want the description

## how you tested the change

Unit tests and integration tests

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [X] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

