### PR TITLE
fix null pointer when creating units

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
@@ -242,9 +242,17 @@ public final class DatatypeUnitResources extends OpenDcsResource
 		DatabaseIO dbIo = getLegacyDatabase();
 		try
 		{
-			EngineeringUnit unit = new EngineeringUnit(fromabbr, eu.getName(), eu.getFamily(), eu.getMeasures());
+			EngineeringUnit unit = new EngineeringUnit(eu.getAbbr(), eu.getName(), eu.getFamily(), eu.getMeasures());
 			EngineeringUnitList euList = new EngineeringUnitList();
 			dbIo.readEngineeringUnitList(euList);
+			if(fromabbr != null && !fromabbr.isEmpty())
+			{
+				EngineeringUnit engineeringUnit = euList.get(fromabbr);
+				if(engineeringUnit != null)
+				{
+					euList.remove(engineeringUnit);
+				}
+			}
 			euList.add(unit);
 			dbIo.writeEngineeringUnitList(euList);
 			return Response.status(HttpServletResponse.SC_CREATED)


### PR DESCRIPTION
update integration test to include rename

## Problem Description
Can't add new engineering units.

Fixes #419 . 


## Solution

Add null pointer fix and update integration test.

## how you tested the change

Integration testing.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [X] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

