### PR TITLE
fix query param separator in ajax request

### DIFF
--- a/opendcs-web-client/src/main/webapp/resources/js/eu_conversions.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/eu_conversions.js
@@ -291,7 +291,7 @@ function deleteEuConversion(event, clickedLink)
 
         show_waiting_modal();
         $.ajax({
-            url: `${window.API_URL}/euconv&euconvid=${ucId}`,
+            url: `${window.API_URL}/euconv?euconvid=${ucId}`,
             type: "DELETE",
             headers: {     
                 "Content-Type": "application/json"   


### PR DESCRIPTION
fixes deleting EU conversion delete

## Problem Description

Cannot delete unit conversion.

Fixes #417 . 

## Solution

Fix ajax query missing `?` separator

## how you tested the change

Tested manually through the user interface.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

