### PR TITLE
fix missing platform sensors on retrieval

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/PlatformResources.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Vector;
+import java.util.stream.Collectors;
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
@@ -74,6 +75,8 @@ import org.opendcs.odcsapi.errorhandling.DatabaseItemNotFoundException;
 import org.opendcs.odcsapi.errorhandling.MissingParameterException;
 import org.opendcs.odcsapi.errorhandling.WebAppException;
 import org.opendcs.odcsapi.util.ApiConstants;
+
+import static java.util.stream.Collectors.toList;
 
 @Path("/")
 public final class PlatformResources extends OpenDcsResource
@@ -272,7 +275,23 @@ public final class PlatformResources extends OpenDcsResource
 		ret.setProperties(platform.getProperties());
 		ret.setName(platform.getSiteName(false));
 		ret.setTransportMedia(map(platform.getTransportMedia()));
+		ret.setPlatformSensors(platform.platformSensors.stream()
+				.map(PlatformResources::map)
+				.collect(toList()));
 		return ret;
+	}
+
+	private static ApiPlatformSensor map(PlatformSensor ps)
+	{
+		ApiPlatformSensor retval = new ApiPlatformSensor();
+		retval.setSensorNum(ps.sensorNumber);
+		if (ps.site != null)
+		{
+			retval.setActualSiteId(ps.site.getId().getValue());
+		}
+		retval.setUsgsDdno(ps.getUsgsDdno());
+		retval.setSensorProps(ps.getProperties());
+		return retval;
 	}
 
 	static ArrayList<ApiTransportMedium> map(Iterator<TransportMedium> transportMedium)

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/PlatformResourcesTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/PlatformResourcesTest.java
@@ -198,6 +198,10 @@ final class PlatformResourcesTest
 		Site site = new Site();
 		site.setId(DbKey.createDbKey(1234L));
 		plat1.setSite(site);
+		PlatformSensor platformSensor = new PlatformSensor(plat1, 1);
+		platformSensor.setProperty("test", "value");
+		platformSensor.setUsgsDdno(1534);
+		plat1.platformSensors.add(platformSensor);
 		PlatformConfig config = new PlatformConfig();
 		config.setId(DbKey.createDbKey(33565L));
 		config.configName = plat1.getConfigName();


### PR DESCRIPTION
## Problem Description

Fixes #412 . 

## Solution

add missing mapping from PlatformSensors to ApiPlatformSensors

## how you tested the change


## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

