### PR TITLE
read data type list to ensure we don't update existing

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/ConfigResources.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Vector;
 import javax.annotation.security.RolesAllowed;
 
+import decodes.db.DataTypeSet;
 import decodes.db.FormatStatement;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -335,7 +336,9 @@ public final class ConfigResources extends OpenDcsResource
 		DatabaseIO dbIo = getLegacyDatabase();
 		try
 		{
-			PlatformConfig pc = map(config);
+			DataTypeSet dataTypeSet = new DataTypeSet();
+			dbIo.readDataTypeSet(dataTypeSet);
+			PlatformConfig pc = map(config, dataTypeSet);
 			dbIo.writeConfig(pc);
 			return Response.status(HttpServletResponse.SC_CREATED)
 					.entity(map(pc))
@@ -351,7 +354,7 @@ public final class ConfigResources extends OpenDcsResource
 		}
 	}
 
-	static PlatformConfig map(ApiPlatformConfig config) throws DbException
+	static PlatformConfig map(ApiPlatformConfig config, DataTypeSet dataTypeSet) throws DbException
 	{
 		try
 		{
@@ -382,7 +385,11 @@ public final class ConfigResources extends OpenDcsResource
 				configSensor.setUsgsStatCode(sensor.getUsgsStatCode());
 				for (Map.Entry<String, String> entry : sensor.getDataTypes().entrySet())
 				{
-					DataType dt = new DataType(entry.getKey(), entry.getValue());
+					DataType dt = dataTypeSet.get(entry.getKey(), entry.getValue());
+					if(dt == null )
+					{
+						dt = new DataType(entry.getKey(), entry.getValue());
+					}
 					configSensor.addDataType(dt);
 				}
 				for (String name : sensor.getProperties().stringPropertyNames())

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/ConfigResourcesTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/ConfigResourcesTest.java
@@ -9,6 +9,8 @@ import java.util.Properties;
 import java.util.Vector;
 
 import decodes.db.ConfigSensor;
+import decodes.db.DataType;
+import decodes.db.DataTypeSet;
 import decodes.db.DecodesScript;
 import decodes.db.FormatStatement;
 import decodes.db.PlatformConfig;
@@ -137,7 +139,11 @@ final class ConfigResourcesTest
 		configSensors.add(configSensor);
 		apiConfig.setConfigSensors(configSensors);
 
-		PlatformConfig config = map(apiConfig);
+		DataTypeSet dataTypeSet = new DataTypeSet();
+		DataType dataType = new DataType("Test data type", "Test data type description");
+		dataType.setId(DbKey.createDbKey(1234L));
+		dataTypeSet.add(dataType);
+		PlatformConfig config = map(apiConfig, dataTypeSet);
 
 		assertNotNull(config);
 		assertEquals(apiConfig.getNumPlatforms(), config.numPlatformsUsing);
@@ -168,6 +174,7 @@ final class ConfigResourcesTest
 			{
 				assertEquals(sensorConfig.getDataType().getStandard(), entry.getKey());
 				assertEquals(sensorConfig.getDataType().getCode(), entry.getValue());
+				assertEquals(dataType.getId(), sensorConfig.getDataType().getId());
 			}
 			assertEquals(apiConfig.getConfigSensors().get(0).getProperties(), sensorConfig.getProperties());
 		}


### PR DESCRIPTION
## Problem Description

Fixes #420 . 


## Solution

read data type list to ensure we don't update existing and use the proper DbKey

## how you tested the change

Unit tested and tested manually through web gui.

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate