### PR TITLE
fix missing platform count in netlist refs

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/NetlistResources.java
@@ -144,6 +144,7 @@ public final class NetlistResources extends OpenDcsResource
 			anlr.setLastModifyTime(nl.lastModifyTime);
 			anlr.setTransportMediumType(nl.transportMediumType);
 			anlr.setSiteNameTypePref(nl.siteNameTypePref);
+			anlr.setNumPlatforms(nl.networkListEntries.size());
 			ret.add(anlr);
 		}
 		return ret;

--- a/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/NetlistResourcesTest.java
+++ b/opendcs-rest-api/src/test/java/org/opendcs/odcsapi/res/NetlistResourcesTest.java
@@ -28,6 +28,10 @@ final class NetlistResourcesTest
 		nl.siteNameTypePref = "TestPref";
 		nl.transportMediumType = "GOES";
 		nl.setId(DbKey.createDbKey(750556L));
+		nl.networkListEntries.put("TestEntry", new NetworkListEntry(nl, "TestEntry"));
+		nl.networkListEntries.put("TestEntry2", new NetworkListEntry(nl, "TestEntry2"));
+		nl.networkListEntries.put("TestEntry3", new NetworkListEntry(nl, "TestEntry3"));
+		nl.networkListEntries.put("TestEntry4", new NetworkListEntry(nl, "TestEntry4"));
 
 		nll.add(nl);
 
@@ -40,6 +44,7 @@ final class NetlistResourcesTest
 		assertEquals(nl.transportMediumType, netlistRefs.get(0).getTransportMediumType());
 		assertEquals(nl.lastModifyTime, netlistRefs.get(0).getLastModifyTime());
 		assertEquals(nl.siteNameTypePref, netlistRefs.get(0).getSiteNameTypePref());
+		assertEquals(nl.networkListEntries.size(), netlistRefs.get(0).getNumPlatforms());
 	}
 
 	@Test


### PR DESCRIPTION
## Problem Description

Netlist platform counts are all 0.

## Solution

Set the count correctly.

## how you tested the change

Tested through gui and unit test.

## Where the following done:

- [X] Tests. Check all that apply:
   - [X] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

