### PR TITLE
fix swaggerui resources incorrectly going in source directory

### DIFF
--- a/opendcs-rest-api/build.gradle
+++ b/opendcs-rest-api/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 tasks.register('extractWebJars', Copy) {
     from zipTree(configurations.webjars.singleFile)
 
-    into file("src/main/webapp/swaggerui")
+    into file("${layout.buildDirectory.get().asFile}/generated/webapp/swaggerui")
     includeEmptyDirs false
     eachFile {
         path -= ~/^.+?\/.+?\/.+?\/.+?\/.+?\//
@@ -85,7 +85,7 @@ jar {
 
 war {
     dependsOn extractWebJars
-    from 'src/main/webapp'
+    from "${layout.buildDirectory.get().asFile}/generated/webapp"
 }
 
 publishing {
@@ -100,7 +100,6 @@ publishing {
 if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     sonarqube {
         properties {
-            property 'sonar.exclusions', 'src/main/webapp/swaggerui/**'
             property 'sonar.coverage.jacoco.xmlReportPaths', "${layout.buildDirectory.get().asFile.toString()}/reports/jacoco/test/jacocoTestReport.xml," +
                     "../opendcs-integration-test/build/reports/jacoco/integrationTestReportCWMS/integrationTestReportCWMS.xml," +
                     "../opendcs-integration-test/build/reports/jacoco/integrationTestReportOpenTSDB/integrationTestReportOpenTSDB.xml"


### PR DESCRIPTION
## Problem Description

Fixes #398 . 

## Solution

update to go under /build under generated sources

## how you tested the change

Tested by running `./gradlew build` and checking the git status. Tested running the web gui that the swagger page still loads.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

