### PR TITLE
set writeCwmsLocations=true until read from database properties

### DIFF
--- a/opendcs-integration-test/src/test/java/org/opendcs/odcsapi/res/it/SiteResourcesIT.java
+++ b/opendcs-integration-test/src/test/java/org/opendcs/odcsapi/res/it/SiteResourcesIT.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Tag("integration-opentsdb-only")
+@Tag("integration")
 @ExtendWith(DatabaseContextProvider.class)
 final class SiteResourcesIT extends BaseIT
 {

--- a/opendcs-integration-test/src/test/resources/org/opendcs/odcsapi/res/it/CWMS/site_get_refs_expected.json
+++ b/opendcs-integration-test/src/test/resources/org/opendcs/odcsapi/res/it/CWMS/site_get_refs_expected.json
@@ -1,12 +1,10 @@
-[
+{
+  "siteId": 4,
+  "sitenames":
   {
-    "siteId": 4,
-    "sitenames":
-    {
-      "PUMP": "Pump Site",
-      "CWMS" : "Pump Site"
-    },
-    "publicName": "Pump Site",
-    "description": "Pump located in NM, USA"
-  }
-]
+    "PUMP": "Pump Site",
+    "CWMS" : "Pump Site"
+  },
+  "publicName": "Pump Site",
+  "description": "Pump located in NM, USA"
+}

--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/OpenDcsDatabaseFactory.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/dao/OpenDcsDatabaseFactory.java
@@ -60,6 +60,7 @@ public final class OpenDcsDatabaseFactory
 			//Temporary workaround until database_properties table is implemented in the schema
 			LOGGER.atWarn().setCause(e).log("Temporary solution forcing OpenTSDB");
 			DecodesSettings decodesSettings = new DecodesSettings();
+			DecodesSettings.instance().writeCwmsLocations = true;
 			decodesSettings.CwmsOfficeId = DbInterface.decodesProperties.getProperty("CwmsOfficeId");
 			try(Connection connection = dataSource.getConnection())
 			{


### PR DESCRIPTION
## Problem Description

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #438. Supersedes https://github.com/opendcs/rest_api/pull/447. 

## Solution

set writeCwmsLocations=true until read from database properties

## how you tested the change

Integration tested against OpenTSDB and CWMS database instances

## Where the following done:

- [x] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [x] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ =x] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
