### PR TITLE
Bug/UI netlist transportmedium

### DIFF
--- a/opendcs-web-client/src/main/webapp/resources/js/datatables/datatables.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/datatables/datatables.js
@@ -662,7 +662,6 @@ class OpenDcsDataTable {
                       }
                   }
               }
-
               $(jqTableId).removeClass("editing");
           }
           if (runAtEndFocusOut != null)
@@ -671,7 +670,6 @@ class OpenDcsDataTable {
           }
       });
   }
-
 }
 
 

--- a/opendcs-web-client/src/main/webapp/resources/js/netlist.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/netlist.js
@@ -421,8 +421,7 @@ function set_netlist_modal(netlistDetails, platformsList, tmTypes)
             var tmDataHtml = "<div>";
             for (var key in curPlatform.transportMedia)
             {
-                //tmDataHtml += key + " - " + curPlatform.transportMedia[key] + "<br>";
-                tmDataHtml += `<div data-transportmedium="${key}">${key} - ${curPlatform.transportMedia[key]}</div><br>`;
+                tmDataHtml += `<div data-transportmedium="${key}">${key} - ${curPlatform.transportMedia[key]}</div>`;
             }
             tmDataHtml += "</div>";
 

--- a/opendcs-web-client/src/main/webapp/resources/js/netlist.js
+++ b/opendcs-web-client/src/main/webapp/resources/js/netlist.js
@@ -244,7 +244,7 @@ function populateNetlistDetails(netlistId)
     if (netlistId != -1) 
     {
         var params = {
-                "netlistid": netlistId
+            "netlistid": netlistId
         };
         $.ajax({
             url: `${window.API_URL}/netlist`,
@@ -418,11 +418,13 @@ function set_netlist_modal(netlistDetails, platformsList, tmTypes)
         {
             var curPlatform = platformsList[key];
             var desc = (curPlatform.description != null ? curPlatform.description : "");
-            var tmDataHtml = "";
+            var tmDataHtml = "<div>";
             for (var key in curPlatform.transportMedia)
             {
-                tmDataHtml += key + " - " + curPlatform.transportMedia[key] + "<br>";
+                //tmDataHtml += key + " - " + curPlatform.transportMedia[key] + "<br>";
+                tmDataHtml += `<div data-transportmedium="${key}">${key} - ${curPlatform.transportMedia[key]}</div><br>`;
             }
+            tmDataHtml += "</div>";
 
             var platformRow = [curPlatform.platformId, curPlatform.name, curPlatform.agency, tmDataHtml, curPlatform.config, desc];
 
@@ -455,6 +457,7 @@ function initializeEvents()
                 function() {
 
             var tsm = $("#transportMediumTypeSelectbox").val();
+            var isGoesVariant = goesTms.includes(tsm);
             var params = {
                     "name": $("#netlistName").val(),
                     "siteNameTypePref": $("#siteNameType").val(),
@@ -512,18 +515,10 @@ function initializeEvents()
                 var allPlatformTms = curData[3].split("<br>");
                 var validTmType = false;
                 allPlatformTms.forEach(ptm => {
-                    if (ptm.startsWith(tsm))
+                    var definedTm = $(ptm).find("div").data("transportmedium");
+                    if (definedTm === tsm || (isGoesVariant && goesTms.includes(definedTm)))
                     {
                         validTmType = true;
-                    }
-                    else
-                    {
-                        goesTms.forEach(tm => {
-                            if (ptm.startsWith(tm))
-                            {
-                                validTmType = true;
-                            }
-                        });
                     }
                     if (!validTmType)
                     {
@@ -691,7 +686,20 @@ function initializeDataTables()
                     for (var x = 0; x < selectedRowData.length; x++)
                     {
                         var curData = selectedRowData[x];
-                        if (curData[3] != val && goesTms.indexOf(curData[3]) == -1 && goesTms.indexOf(val) == -1)
+                        var curDataHtml = $(curData[3]).find("[data-transportmedium]");
+                        var tmMatched = false;
+                        var isGoesVariant = goesTms.includes(val);
+                        for (var y = 0; y < curDataHtml.length; y++)
+                        {
+                            var linkedTm = $(curDataHtml[y]).data("transportmedium");
+                            if (linkedTm === val || (isGoesVariant && goesTms.includes(linkedTm)))
+                            {
+                                //Found a linked trasnport medium
+                                tmMatched = true;
+                                break;
+                            }
+                        }
+                        if (!tmMatched)
                         {
                             set_yesno_modal(
                                     "Transport Medium Type Mismatch", 


### PR DESCRIPTION
## Problem Description
When sorting through platforms on the netlist page, (when you click the transport medium dropdown), it was not sorting properly.  It was improperly identifying the transport medium, making it difficult to save the netlist properly.

<!-- if your PR does not address an open issue you can remove this line -->
Fixes #453

<!-- if you are referencing a specific issue a problem description is not required -->
Transport medium selection was not working properly.  Now the user can properly select transport medium, as well as identify properly when there is a mismatch.

## Solution
Added data-elements and divs to the field in the datatable, and identifying them with jquery selectors, rather than lookin at the straight html text.

## how you tested the change
manually tested several permutations, going from goes to all three goes variants, as well as going from iridium to goes and goes to iridium with the different transport medium types selected.

Describe what was done to test the change. This section can be left blank 
if automated tests demonstrating usage are provided in the PR.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

If you aren't sure leave unchecked and we will help guide you to want needs changing where.
