### PR TITLE
force the db key to be null when editing eu conversion

### DIFF
--- a/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
+++ b/opendcs-rest-api/src/main/java/org/opendcs/odcsapi/res/DatatypeUnitResources.java
@@ -412,6 +412,7 @@ public final class DatatypeUnitResources extends OpenDcsResource
 			if(ucId != null)
 			{
 				dbIo.deleteUnitConverter(ucId);
+				unitConverterDb.forceSetId(DbKey.NullKey);
 			}
 			dbIo.insertUnitConverter(unitConverterDb);
 			return Response.status(HttpServletResponse.SC_CREATED).entity(map(unitConverterDb)).build();


### PR DESCRIPTION
## Problem Description

Fixes #418 . 

## Solution

force the db key to be null when editing eu conversion

## how you tested the change

Tested through web gui.

## Where the following done:

- [ ] Tests. Check all that apply:
   - [ ] Unit tests created or modified that run during ant test.
   - [ ] Integration tests created or modified that run during integration testing
         (Formerly called regression tests.)
   - [ ] Test procedure descriptions for manual testing
- [ ] Was relevant documentation updated?
- [ ] Were relevant config element (e.g. XML data) updated as appropriate

